### PR TITLE
perf(compiler): dispatch List Eq-family intrinsics on packed (lazily-decoded) lists

### DIFF
--- a/docs/internal/CODEGEN_IMPROVEMENT_PLAN.md
+++ b/docs/internal/CODEGEN_IMPROVEMENT_PLAN.md
@@ -663,9 +663,14 @@ flexible case on builtin Bool/Integer/Data, Agda-certified passes
   intrinsics. Measured cost of the miss: +2,528 mem / +644,996 steps for a
   single `signatories.contains` in the CAPE linear_vesting validator. Fix:
   `dispatchReprNames` lets a `PackedSumDataList` receiver fall back to the
-  `BuiltinList` provider name, scoped to the `EqStripMethods` family — those
-  providers return scalars or relabeled Data lists, so no
-  element-representation mislabeling is possible.
+  `BuiltinList` provider name, scoped to the `PackedListViewMethods` family —
+  those providers return scalars or Data lists that they relabel from the
+  element TYPE (`typeProxyRepr` in `deleteFirst`/`distinct`/`diff`), so no
+  element-representation mislabeling is possible. That set was split out of
+  `EqStripMethods` in the follow-up refactor: the two answer different
+  questions (drop the trailing implicit `Eq` — an arity property — vs safe
+  under the packed → `BuiltinList` view — a representation property) and only
+  happen to hold the same List methods today.
 - **Open:** route the spine ops (`head`/`tail`/`isEmpty`/`at`/`drop`) the
   same way. A broader first attempt did this and was backed out: it
   mislabeled element representations (`head`/`at` on a packed
@@ -676,6 +681,25 @@ flexible case on builtin Bool/Integer/Data, Agda-certified passes
   every realistic validator 2–13% (auction, betting, AMM, payment splitter,
   Knights, HTLC). Fixing the element-repr labeling of spine-op dispatch on
   packed receivers recovers those forfeited wins.
+- **Where that mislabel comes from** (fix site, established during review of
+  the Eq-family commit): `ListReprRules.elemRepr`
+  (`intrinsics/ListIntrinsics.scala:30`) derives the result's element repr
+  from the RECEIVER's repr, and `PackedSumDataList` carries no element repr,
+  so it falls through to `case _ => defaultRepresentation(outTp)` — the
+  *native* default — while the value the provider body actually unpacked is
+  `SumBuiltinList(defaultDataRepresentation(elemType))` (the `unListData`
+  conversion at `typegens/SumListEmitterCommon.scala:721-727`). `listRepr`
+  (`ListIntrinsics.scala:27`) has the mirror problem: it returns `inRepr`
+  unchanged, so `tail`/`drop` on a packed receiver claim a packed result the
+  body no longer produces. Candidate fix: give both a `PackedSumDataList`
+  case mirroring that conversion — `elemRepr` →
+  `defaultDataRepresentation(outTp)`, `listRepr` →
+  `SumBuiltinList(defaultDataRepresentation(elemType(outTp)))` — and then add
+  the spine ops to `PackedListViewMethods`. This cannot instead be fixed
+  inside the providers with `typeProxyRepr`: `BuiltinListOperations.head`/
+  `tail` also serve `SumBuiltinList(native-element)` receivers (the second
+  name `representationNames` returns for those), where the element genuinely
+  is native, so the labelling has to stay receiver-derived.
 - **Also open:** `find` has no BuiltinList-repr provider at all (only a
   native-list one), so packed-list `find` still lowers the generic fixpoint
   body with a data-`Some` allocation per match.

--- a/docs/internal/CODEGEN_IMPROVEMENT_PLAN.md
+++ b/docs/internal/CODEGEN_IMPROVEMENT_PLAN.md
@@ -649,6 +649,39 @@ flexible case on builtin Bool/Integer/Data, Agda-certified passes
 - **Validate:** oracle-style (sparse access) AND fold-heavy (dense access)
   benchmarks must both stay at their current best or improve.
 
+### T17. Packed-list intrinsic dispatch: Eq family DONE, spine ops open
+
+- **Done (2026-08-25):** `IntrinsicResolver` never dispatched intrinsics on a
+  `PackedSumDataList` receiver (a still-packed `Data` list — the
+  representation of every lazily-decoded ledger list, e.g.
+  `TxInfo.signatories`): `representationNames` mapped that repr only to the
+  name `"PackedSumDataList"`, which has no registry entry, so
+  `List.contains`/`indexOf`/`deleteFirst`/`distinct`/`diff` silently lowered
+  their generic prelude bodies (a data-encoded `Some` allocated per element
+  plus a dead `Eq` closure that `EqStrip` never removed, because stripping
+  only happens when dispatch fires) instead of the `equalsData`-scan
+  intrinsics. Measured cost of the miss: +2,528 mem / +644,996 steps for a
+  single `signatories.contains` in the CAPE linear_vesting validator. Fix:
+  `dispatchReprNames` lets a `PackedSumDataList` receiver fall back to the
+  `BuiltinList` provider name, scoped to the `EqStripMethods` family — those
+  providers return scalars or relabeled Data lists, so no
+  element-representation mislabeling is possible.
+- **Open:** route the spine ops (`head`/`tail`/`isEmpty`/`at`/`drop`) the
+  same way. A broader first attempt did this and was backed out: it
+  mislabeled element representations (`head`/`at` on a packed
+  `List[ByteString]` returned a still-`Data` value labeled native —
+  MembershipToken failed at runtime with `Blake2b_256` applied to
+  `VCon(Data(...))`) and regressed degenerate micro cases (`tail` +396 mem /
+  +189,448 steps; `drop 0`/`-1`/empty +150–183k steps), even while cutting
+  every realistic validator 2–13% (auction, betting, AMM, payment splitter,
+  Knights, HTLC). Fixing the element-repr labeling of spine-op dispatch on
+  packed receivers recovers those forfeited wins.
+- **Also open:** `find` has no BuiltinList-repr provider at all (only a
+  native-list one), so packed-list `find` still lowers the generic fixpoint
+  body with a data-`Some` allocation per match.
+- **Validate:** full corpus; MembershipToken is the regression sentinel for
+  element-repr labeling.
+
 ## 7. Further research recommendations
 
 1. **Machine-step attribution.** The profiling CEK attributes builtin costs

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -49,6 +49,33 @@ object IntrinsicResolver {
       OptionModule + ".contains"
     )
 
+    /** Methods that may dispatch a still-packed (`PackedSumDataList`) receiver through the
+      * `BuiltinList` (Data-element) providers, by unpacking it on demand (`unListData`, O(1)). See
+      * `dispatchReprNames`.
+      *
+      * Safe only for methods that never hand an element back under the receiver's own labelling:
+      * these return a scalar (`contains`/`indexOf`) or a Data-element list that the provider
+      * relabels from the element TYPE via `typeProxyRepr` (`deleteFirst`/`distinct`/`diff`), so a
+      * packed receiver cannot mislabel anything. The spine ops
+      * (`head`/`tail`/`isEmpty`/`at`/`drop`) are deliberately absent: their repr rules read the
+      * element repr out of the RECEIVER's repr, and `PackedSumDataList` carries none, so
+      * `ListReprRules.elemRepr` falls through to the native default and labels a still-`Data`
+      * element as native (`Blake2b_256` applied to `VCon(Data)` in MembershipToken). Tracked as T17
+      * in docs/internal/CODEGEN_IMPROVEMENT_PLAN.md.
+      *
+      * Deliberately distinct from [[EqStripMethods]], which today holds the same List methods: that
+      * set answers "drop the trailing implicit `Eq`" (an arity property), this one answers "safe
+      * under the packed → BuiltinList view" (a representation property). An `Eq`-taking method that
+      * returned an element natively would belong in the first set and not in this one.
+      */
+    private val PackedListViewMethods: Set[String] = Set(
+      ListModule + ".contains",
+      ListModule + ".indexOf",
+      ListModule + ".deleteFirst",
+      ListModule + ".distinct",
+      ListModule + ".diff"
+    )
+
     private val ListOps = "scalus.compiler.intrinsics.BuiltinListOperations$"
     private val ListOpsV11 = "scalus.compiler.intrinsics.BuiltinListOperationsV11$"
     private val NativeListOps = "scalus.compiler.intrinsics.IntrinsicsNativeList$"
@@ -125,6 +152,11 @@ object IntrinsicResolver {
 
     // Representation name constants for registry lookup
     private val BuiltinListRepr = "BuiltinList"
+
+    /** Name of a still-packed `Data` list. No registry entry carries it — a packed receiver only
+      * ever dispatches through the [[BuiltinListRepr]] view, see [[dispatchReprNames]].
+      */
+    private val PackedSumDataListRepr = "PackedSumDataList"
     private val NativeBuiltinListRepr = "NativeBuiltinList"
     private val UplcConstrListRepr = "UplcConstrList"
     private val UplcConstrOptionRepr = "UplcConstrOption"
@@ -235,6 +267,51 @@ object IntrinsicResolver {
         case SIR.LamAbs(_, body, _, _) => 1 + countTopLambdas(body)
         case _                         => 0
 
+    /** The registry entry chosen for a call: its provider binding, the rule tables to apply to the
+      * result and to the first argument, and the dispatch priority it won at (debug logging only).
+      */
+    private case class SelectedProvider(
+        binding: Binding,
+        reprRules: Map[String, scalus.compiler.intrinsics.ReprRule],
+        argConvertRules: Map[String, scalus.compiler.intrinsics.ArgReprConvertRule],
+        reprPriority: Int
+    )
+
+    /** Pick the provider for `methodName` among `entries`, given the receiver's dispatch names
+      * (most specific first, see [[dispatchReprNames]]).
+      *
+      * The entry matching the most specific name wins; ties go to the highest `minPV` the target
+      * protocol version satisfies. A [[WildcardRepr]] entry matches any receiver but at the lowest
+      * priority, and only for methods it carries a repr rule for. An entry whose provider module
+      * has no binding for `methodName` is skipped, leaving any lower-priority match in place.
+      */
+    private def selectProvider(
+        entries: List[RegistryEntry],
+        reprNames: List[String],
+        methodName: String
+    )(using lctx: LoweringContext): Option[SelectedProvider] = {
+        val pvVersion = lctx.targetProtocolVersion.version
+        var best: Option[SelectedProvider] = None
+        var bestPV = -1
+        var bestReprPriority = Int.MaxValue
+        for (repr, minPV, providerModuleName, reprRules, argConvertRules) <- entries do {
+            val reprPriority = reprNames.indexOf(repr) match
+                case -1 if repr == WildcardRepr && reprRules.contains(methodName) =>
+                    reprNames.size // wildcard has lowest priority
+                case -1 => -1 // no match
+                case i  => i
+            if reprPriority >= 0 && pvVersion >= minPV &&
+                (reprPriority < bestReprPriority || (reprPriority == bestReprPriority && minPV > bestPV))
+            then
+                lctx.findProviderBinding(providerModuleName, methodName).foreach { b =>
+                    best = Some(SelectedProvider(b, reprRules, argConvertRules, reprPriority))
+                    bestPV = minPV
+                    bestReprPriority = reprPriority
+                }
+        }
+        best
+    }
+
     def tryResolveFull(
         head: SIR,
         argSirs0: scala.List[SIR],
@@ -263,37 +340,13 @@ object IntrinsicResolver {
                 registry.get(moduleName) match
                     case None => None
                     case Some(entries) =>
-                        val pvVersion = lctx.targetProtocolVersion.version
-                        var bestBinding: Option[Binding] = None
-                        var bestPV = -1
-                        var bestReprPriority = Int.MaxValue
-                        var bestReprRules: Map[String, scalus.compiler.intrinsics.ReprRule] =
-                            Map.empty
-                        var bestArgConvertRules
+                        val selected = selectProvider(entries, reprNames, methodName)
+                        val bestReprRules: Map[String, scalus.compiler.intrinsics.ReprRule] =
+                            selected.map(_.reprRules).getOrElse(Map.empty)
+                        val bestArgConvertRules
                             : Map[String, scalus.compiler.intrinsics.ArgReprConvertRule] =
-                            Map.empty
-                        for (repr, minPV, providerModuleName, reprRules, argConvertRules) <-
-                                entries
-                        do {
-                            val reprPriority = reprNames.indexOf(repr) match {
-                                case -1 if repr == WildcardRepr && reprRules.contains(methodName) =>
-                                    reprNames.size
-                                case -1 => -1
-                                case i  => i
-                            }
-                            if reprPriority >= 0 && pvVersion >= minPV &&
-                                (reprPriority < bestReprPriority || (reprPriority == bestReprPriority && minPV > bestPV))
-                            then
-                                lctx.findProviderBinding(providerModuleName, methodName).foreach {
-                                    b =>
-                                        bestBinding = Some(b)
-                                        bestPV = minPV
-                                        bestReprPriority = reprPriority
-                                        bestReprRules = reprRules
-                                        bestArgConvertRules = argConvertRules
-                                }
-                        }
-                        bestBinding.flatMap { binding =>
+                            selected.map(_.argConvertRules).getOrElse(Map.empty)
+                        selected.map(_.binding).flatMap { binding =>
                             val depth = countTopLambdas(binding.value)
                             if depth != argSirs.length then None
                             else {
@@ -411,47 +464,26 @@ object IntrinsicResolver {
                             lctx.log(
                               s"IntrinsicResolver: reprNames=$reprNames entries=${entries.map(e => s"(${e._1},${e._2},${e._3})").mkString(",")}"
                             )
-                        val pvVersion = lctx.targetProtocolVersion.version
-
                         // Find best matching provider: most specific repr name first,
                         // then highest minPV that satisfies constraints
-                        var bestBinding: Option[Binding] = None
-                        var bestPV = -1
-                        var bestReprPriority = Int.MaxValue
-                        var bestReprRules: Map[String, scalus.compiler.intrinsics.ReprRule] =
-                            Map.empty
-                        var bestArgConvertRules
+                        val selected = selectProvider(entries, reprNames, methodName)
+                        val bestReprRules: Map[String, scalus.compiler.intrinsics.ReprRule] =
+                            selected.map(_.reprRules).getOrElse(Map.empty)
+                        val bestArgConvertRules
                             : Map[String, scalus.compiler.intrinsics.ArgReprConvertRule] =
-                            Map.empty
-                        for (repr, minPV, providerModuleName, reprRules, argConvertRules) <-
-                                entries
-                        do {
-                            val reprPriority = reprNames.indexOf(repr) match {
-                                case -1 if repr == WildcardRepr && reprRules.contains(methodName) =>
-                                    reprNames.size // wildcard has lowest priority
-                                case -1 => -1 // no match
-                                case i  => i
-                            }
-                            if reprPriority >= 0 && pvVersion >= minPV &&
-                                (reprPriority < bestReprPriority || (reprPriority == bestReprPriority && minPV > bestPV))
-                            then
-                                lctx.findProviderBinding(providerModuleName, methodName).foreach {
-                                    b =>
-                                        bestBinding = Some(b)
-                                        bestPV = minPV
-                                        bestReprPriority = reprPriority
-                                        bestReprRules = reprRules
-                                        bestArgConvertRules = argConvertRules
-                                }
-                        }
+                            selected.map(_.argConvertRules).getOrElse(Map.empty)
 
-                        if lctx.debug && bestBinding.isEmpty then
-                            lctx.log(s"IntrinsicResolver: no binding found for $methodName")
-                        if lctx.debug && bestBinding.isDefined then
-                            lctx.log(
-                              s"IntrinsicResolver: FOUND binding for $methodName, reprPriority=$bestReprPriority"
-                            )
-                        bestBinding.map { binding =>
+                        if lctx.debug then
+                            selected match
+                                case None =>
+                                    lctx.log(
+                                      s"IntrinsicResolver: no binding found for $methodName"
+                                    )
+                                case Some(sel) =>
+                                    lctx.log(
+                                      s"IntrinsicResolver: FOUND binding for $methodName, reprPriority=${sel.reprPriority}"
+                                    )
+                        selected.map(_.binding).map { binding =>
                             // Before substituting the argSir into the provider body, rewrite any
                             // inner ExternalVar references to intrinsic-dispatched modules so
                             // their TypeLambda TypeVars are Transparent. The Scala plugin stamps
@@ -537,22 +569,21 @@ object IntrinsicResolver {
                         }
     }
 
-    /** Extract module name and method name from a function SIR node. */
     /** Representation names to use for provider dispatch of `moduleName.methodName` on a receiver
-      * in `repr`.
+      * in `repr`, most specific first.
       *
-      * Besides the plain [[representationNames]] mapping, a receiver in `PackedSumDataList` (a
-      * still-packed `Data` list, the representation of every lazily-decoded ledger list such as
-      * `TxInfo.signatories`) may additionally dispatch to the `BuiltinList` (Data-element)
-      * providers — but only for the structural-equality methods ([[EqStripMethods]]). For those,
-      * the generic prelude bodies are known-bad on packed lists (an `Option` allocated per step
-      * plus a dead `Eq` closure; measured +2,528 mem / +644,996 steps for a single
-      * `signatories.contains` on CAPE linear_vesting), while the providers return scalars or
-      * relabeled Data lists, so no element-representation mislabeling can occur. The spine ops
-      * (`head`/`tail`/`isEmpty`/`at`/`drop`) are deliberately NOT routed this way: dispatching them
-      * on packed receivers mislabels element representations (e.g. `Blake2b_256` applied to a
-      * still-`Data` "ByteString" in MembershipToken) and regresses degenerate micro cases — fixing
-      * that is tracked in docs/internal/CODEGEN_IMPROVEMENT_PLAN.md (T17).
+      * Besides the plain [[representationNames]] mapping, a packed receiver (a still-packed `Data`
+      * list — the representation of every lazily-decoded ledger list, such as `TxInfo.signatories`)
+      * may additionally dispatch to the `BuiltinList` (Data-element) providers, at lowest priority,
+      * for the methods in [[PackedListViewMethods]] (which see for why only those). For those, the
+      * generic prelude bodies are known-bad on packed lists (an `Option` allocated per step plus a
+      * dead `Eq` closure; measured +2,528 mem / +644,996 steps for a single `signatories.contains`
+      * on CAPE linear_vesting).
+      *
+      * The packed receiver is recognised by NAME rather than by `repr ==
+      * SumCaseClassRepresentation.PackedSumDataList`, so that it is also seen through a
+      * [[SumCaseClassRepresentation.SumReprProxy]] — which [[representationNames]] dereferences —
+      * instead of silently losing the view the way the missing registry entry did.
       */
     private def dispatchReprNames(
         repr: LoweredValueRepresentation,
@@ -560,12 +591,13 @@ object IntrinsicResolver {
         methodName: String
     ): List[String] = {
         val names = representationNames(repr)
-        if repr == SumCaseClassRepresentation.PackedSumDataList
-            && EqStripMethods.contains(s"$moduleName.$methodName")
+        if names.contains(PackedSumDataListRepr)
+            && PackedListViewMethods.contains(s"$moduleName.$methodName")
         then names :+ BuiltinListRepr
         else names
     }
 
+    /** Extract module name and method name from a function SIR node. */
     private def extractModuleAndMethod(f: SIR): Option[(String, String)] = f match
         case SIR.Var(name, _, _) =>
             val lastDot = name.lastIndexOf('.')
@@ -679,7 +711,7 @@ object IntrinsicResolver {
         case SumCaseClassRepresentation.SumPairBuiltinList(_, _) =>
             List(PairListRepr)
         case SumCaseClassRepresentation.PackedSumDataList =>
-            List("PackedSumDataList")
+            List(PackedSumDataListRepr)
         case SumCaseClassRepresentation.DataConstr =>
             List("DataConstr")
         case _ =>

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/IntrinsicResolver.scala
@@ -259,7 +259,7 @@ object IntrinsicResolver {
                         argSirs0.dropRight(1)
                     else argSirs0
                 val firstArgRepr = firstLoweredOnly.representation
-                val reprNames = representationNames(firstArgRepr)
+                val reprNames = dispatchReprNames(firstArgRepr, moduleName, methodName)
                 registry.get(moduleName) match
                     case None => None
                     case Some(entries) =>
@@ -405,7 +405,8 @@ object IntrinsicResolver {
                 registry.get(moduleName) match
                     case None => None
                     case Some(entries) =>
-                        val reprNames = representationNames(loweredArg.representation)
+                        val reprNames =
+                            dispatchReprNames(loweredArg.representation, moduleName, methodName)
                         if lctx.debug then
                             lctx.log(
                               s"IntrinsicResolver: reprNames=$reprNames entries=${entries.map(e => s"(${e._1},${e._2},${e._3})").mkString(",")}"
@@ -537,6 +538,34 @@ object IntrinsicResolver {
     }
 
     /** Extract module name and method name from a function SIR node. */
+    /** Representation names to use for provider dispatch of `moduleName.methodName` on a receiver
+      * in `repr`.
+      *
+      * Besides the plain [[representationNames]] mapping, a receiver in `PackedSumDataList` (a
+      * still-packed `Data` list, the representation of every lazily-decoded ledger list such as
+      * `TxInfo.signatories`) may additionally dispatch to the `BuiltinList` (Data-element)
+      * providers — but only for the structural-equality methods ([[EqStripMethods]]). For those,
+      * the generic prelude bodies are known-bad on packed lists (an `Option` allocated per step
+      * plus a dead `Eq` closure; measured +2,528 mem / +644,996 steps for a single
+      * `signatories.contains` on CAPE linear_vesting), while the providers return scalars or
+      * relabeled Data lists, so no element-representation mislabeling can occur. The spine ops
+      * (`head`/`tail`/`isEmpty`/`at`/`drop`) are deliberately NOT routed this way: dispatching them
+      * on packed receivers mislabels element representations (e.g. `Blake2b_256` applied to a
+      * still-`Data` "ByteString" in MembershipToken) and regresses degenerate micro cases — fixing
+      * that is tracked in docs/internal/CODEGEN_IMPROVEMENT_PLAN.md (T17).
+      */
+    private def dispatchReprNames(
+        repr: LoweredValueRepresentation,
+        moduleName: String,
+        methodName: String
+    ): List[String] = {
+        val names = representationNames(repr)
+        if repr == SumCaseClassRepresentation.PackedSumDataList
+            && EqStripMethods.contains(s"$moduleName.$methodName")
+        then names :+ BuiltinListRepr
+        else names
+    }
+
     private def extractModuleAndMethod(f: SIR): Option[(String, String)] = f match
         case SIR.Var(name, _, _) =>
             val lastDot = name.lastIndexOf('.')

--- a/scalus-core/shared/src/test/scala/scalus/prelude/ListTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/prelude/ListTest.scala
@@ -1963,7 +1963,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.empty[BigInt],
           BigInt(-1),
           Seq(
-            compilerOptions -> ExUnits(memory = 4528, steps = 901260)
+            compilerOptions -> ExUnits(memory = 2632, steps = 426033)
           )
         )
     }
@@ -1974,7 +1974,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.single(1),
           BigInt(0),
           Seq(
-            compilerOptions -> ExUnits(memory = 7289, steps = 2_686757)
+            compilerOptions -> ExUnits(memory = 3433, steps = 1_588576)
           )
         )
     }
@@ -1985,7 +1985,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.single(1),
           BigInt(-1),
           Seq(
-            compilerOptions -> ExUnits(memory = 6731, steps = 2_389011)
+            compilerOptions -> ExUnits(memory = 4835, steps = 1_913784)
           )
         )
     }
@@ -1996,7 +1996,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           BigInt(1),
           Seq(
-            compilerOptions -> ExUnits(memory = 9492, steps = 4_174508)
+            compilerOptions -> ExUnits(memory = 5636, steps = 3_076327)
           )
         )
     }
@@ -2007,7 +2007,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           BigInt(-1),
           Seq(
-            compilerOptions -> ExUnits(memory = 8934, steps = 3_876762)
+            compilerOptions -> ExUnits(memory = 7038, steps = 3_401535)
           )
         )
     }
@@ -2472,7 +2472,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.empty[BigInt],
           List.empty[BigInt],
           Seq(
-            compilerOptions -> ExUnits(memory = 2632, steps = 426033)
+            compilerOptions -> ExUnits(memory = 2432, steps = 394033)
           )
         )
     }
@@ -2483,7 +2483,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.single(1),
           List.empty[BigInt],
           Seq(
-            compilerOptions -> ExUnits(memory = 3433, steps = 1_588576)
+            compilerOptions -> ExUnits(memory = 3233, steps = 1_556576)
           )
         )
     }
@@ -2494,7 +2494,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           Cons(BigInt(2), Nil),
           Seq(
-            compilerOptions -> ExUnits(memory = 3433, steps = 1_588576)
+            compilerOptions -> ExUnits(memory = 3233, steps = 1_556576)
           )
         )
     }
@@ -2505,7 +2505,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           Cons(BigInt(1), Cons(BigInt(2), Nil)),
           Seq(
-            compilerOptions -> ExUnits(memory = 6898, steps = 3_311843)
+            compilerOptions -> ExUnits(memory = 6698, steps = 3_279843)
           )
         )
     }
@@ -2516,7 +2516,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           List.single(BigInt(1)),
           Seq(
-            compilerOptions -> ExUnits(memory = 5566, steps = 3_031481)
+            compilerOptions -> ExUnits(memory = 5366, steps = 2_999481)
           )
         )
     }
@@ -2527,7 +2527,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(1, Nil)),
           List.single(BigInt(1)),
           Seq(
-            compilerOptions -> ExUnits(memory = 3433, steps = 1_588576)
+            compilerOptions -> ExUnits(memory = 3233, steps = 1_556576)
           )
         )
     }
@@ -2763,7 +2763,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.empty[BigInt],
           List.empty[BigInt],
           Seq(
-            compilerOptions -> ExUnits(memory = 6996, steps = 1_165899)
+            compilerOptions -> ExUnits(memory = 3732, steps = 602033)
           )
         )
     }
@@ -2774,7 +2774,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.single(1),
           List.single(BigInt(1)),
           Seq(
-            compilerOptions -> ExUnits(memory = 15352, steps = 2_892676)
+            compilerOptions -> ExUnits(memory = 8296, steps = 1_466757)
           )
         )
     }
@@ -2785,7 +2785,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           Cons(BigInt(1), Cons(BigInt(2), Nil)),
           Seq(
-            compilerOptions -> ExUnits(memory = 25309, steps = 5_909996)
+            compilerOptions -> ExUnits(memory = 14461, steps = 3_622024)
           )
         )
     }
@@ -2796,7 +2796,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(1, Nil)),
           List.single(BigInt(1)),
           Seq(
-            compilerOptions -> ExUnits(memory = 21945, steps = 5_272000)
+            compilerOptions -> ExUnits(memory = 11597, steps = 3_029300)
           )
         )
     }
@@ -2807,7 +2807,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Cons(1, Nil))),
           Cons(BigInt(1), Cons(BigInt(2), Nil)),
           Seq(
-            compilerOptions -> ExUnits(memory = 33503, steps = 9_579863)
+            compilerOptions -> ExUnits(memory = 19363, steps = 6_475110)
           )
         )
     }
@@ -2827,7 +2827,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.empty[BigInt],
           List.empty[BigInt],
           Seq(
-            compilerOptions -> ExUnits(memory = 3164, steps = 580466)
+            compilerOptions -> ExUnits(memory = 2632, steps = 426033)
           )
         )
     }
@@ -2838,7 +2838,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.single(1),
           List.single(BigInt(1)),
           Seq(
-            compilerOptions -> ExUnits(memory = 3364, steps = 612466)
+            compilerOptions -> ExUnits(memory = 3032, steps = 490033)
           )
         )
     }
@@ -2849,7 +2849,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           List.empty[BigInt],
           List.empty[BigInt],
           Seq(
-            compilerOptions -> ExUnits(memory = 3164, steps = 580466)
+            compilerOptions -> ExUnits(memory = 2632, steps = 426033)
           )
         )
     }
@@ -2862,7 +2862,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Seq(
             // diff is intrinsified composing the eq-stripped `deleteFirst` → slightly cheaper than
             // the prelude (which threaded a dead `Eq`). See v3-eq-eliminating.md.
-            compilerOptions -> ExUnits(memory = 6797, steps = 2_265442)
+            compilerOptions -> ExUnits(memory = 6133, steps = 2_020576)
           )
         )
     }
@@ -2873,7 +2873,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           Cons(BigInt(1), Nil),
           Seq(
-            compilerOptions -> ExUnits(memory = 9130, steps = 3_740347)
+            compilerOptions -> ExUnits(memory = 8666, steps = 3_527481)
           )
         )
     }
@@ -2884,7 +2884,7 @@ class ListTest extends AnyFunSuite with EvalTestKit {
           Cons(1, Cons(2, Nil)),
           Cons(BigInt(1), Cons(BigInt(2), Nil)),
           Seq(
-            compilerOptions -> ExUnits(memory = 10462, steps = 4_020709)
+            compilerOptions -> ExUnits(memory = 9998, steps = 3_807843)
           )
         )
     }

--- a/scalus-examples/jvm/src/test/scala/scalus/benchmarks/ClausifyTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/benchmarks/ClausifyTest.scala
@@ -47,8 +47,8 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 32_961305, steps = 9588_324977L),
-                  since38 = ExUnits(memory = 32_455385, steps = 9407_530113L)
+                  pre38 = ExUnits(memory = 32_412897, steps = 9467_869521L),
+                  since38 = ExUnits(memory = 31_906977, steps = 9287_074657L)
                 )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 75014277L, steps = 22595514040L)
@@ -83,8 +83,8 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 41_365629, steps = 11992_356749L),
-                  since38 = ExUnits(memory = 40_837389, steps = 11803_585641L)
+                  pre38 = ExUnits(memory = 40_639989, steps = 11832_961469L),
+                  since38 = ExUnits(memory = 40_111749, steps = 11644_190361L)
                 )
             else
                 options.targetLoweringBackend match {
@@ -122,8 +122,8 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 111_145438, steps = 32139_756569L),
-                  since38 = ExUnits(memory = 109_956898, steps = 31715_021576L)
+                  pre38 = ExUnits(memory = 109_309234, steps = 31736_372906L),
+                  since38 = ExUnits(memory = 108_120694, steps = 31311_637913L)
                 )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 248968345L, steps = 74900219564L)
@@ -1097,8 +1097,8 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 148_946579, steps = 42701_336421L),
-                  since38 = ExUnits(memory = 147_758039, steps = 42276_601428L)
+                  pre38 = ExUnits(memory = 145_537115, steps = 41969_044053L),
+                  since38 = ExUnits(memory = 144_348575, steps = 41544_309060L)
                 )
             else ExUnits(memory = 344589971L, steps = 100725854354L)
         // val scalusBudget = ExUnits(memory = 214968623L, steps = 37733187149L)
@@ -1127,8 +1127,8 @@ class ClausifyTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 536_546359, steps = 154710_664941L),
-                  since38 = ExUnits(memory = 531_844279, steps = 153030_336205L)
+                  pre38 = ExUnits(memory = 529_174519, steps = 153091_026261L),
+                  since38 = ExUnits(memory = 524_472439, steps = 151410_697525L)
                 )
             else ExUnits(memory = 1205574641L, steps = 363306861308L)
         // val scalusBudget = ExUnits(memory = 736503639L, steps = 127163562591L)

--- a/scalus-examples/jvm/src/test/scala/scalus/benchmarks/knightsdata/KnightsDataTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/benchmarks/knightsdata/KnightsDataTest.scala
@@ -54,8 +54,8 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 107_566928, steps = 34868_254333L),
-                  since38 = ExUnits(memory = 93_257588, steps = 29959_961275L)
+                  pre38 = ExUnits(memory = 105_769440, steps = 34334_298482L),
+                  since38 = ExUnits(memory = 91_460100, steps = 29426_005424L)
                 )
             else if options.targetLoweringBackend == TargetLoweringBackend.SirToUplcV3Lowering
             then ExUnits(memory = 324_452274L, steps = 92346_941030L)
@@ -157,8 +157,8 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 192_655624, steps = 82527_132792L),
-                  since38 = ExUnits(memory = 179_591884, steps = 78045_729674L)
+                  pre38 = ExUnits(memory = 190_149656, steps = 81793_718476L),
+                  since38 = ExUnits(memory = 177_085916, steps = 77312_315358L)
                 )
             else
                 options.targetLoweringBackend match
@@ -262,8 +262,8 @@ class KnightsDataTest extends AnyFunSuite, ScalusTest:
         val scalusBudget =
             if options.targetProtocolVersion >= MajorProtocolVersion.vanRossemPV then
                 ScalaCompilerVersion.baseline(
-                  pre38 = ExUnits(memory = 305_323113, steps = 146262_310181L),
-                  since38 = ExUnits(memory = 290_991213, steps = 141346_369566L)
+                  pre38 = ExUnits(memory = 302_034953, steps = 145298_597251L),
+                  since38 = ExUnits(memory = 287_703053, steps = 140382_656636L)
                 )
             else
                 options.targetLoweringBackend match {

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/HelloCardanoTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/HelloCardanoTest.scala
@@ -20,7 +20,7 @@ class HelloCardanoTest extends AnyFunSuite with ScalusTest {
     private val contract = HelloCardanoContract.compiled.withErrorTraces
 
     test(s"Hello Cardano script size is ${contract.script.script.size} bytes") {
-        assert(contract.script.script.size == 316)
+        assert(contract.script.script.size == 271)
     }
 
     test("Hello Cardano") {
@@ -33,7 +33,7 @@ class HelloCardanoTest extends AnyFunSuite with ScalusTest {
         )
 
         // Using HelloCardanoContract.compiled.withErrorTraces (Options.release with generateErrorTraces=true)
-        val scalusBudget = ExUnits(memory = 16286, steps = 6_028388)
+        val scalusBudget = ExUnits(memory = 14058, steps = 5_431392)
 
         val applied = contract.program $ context.toData
         val result = applied.evaluateDebug

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/auction/AuctionValidatorTest.scala
@@ -67,8 +67,8 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
         ).runWithBudget()
         assert(
           budget == ScalaCompilerVersion.baseline(
-            pre38 = ExUnits(memory = 90771, steps = 36_577723),
-            since38 = ExUnits(memory = 87715, steps = 35_499861)
+            pre38 = ExUnits(memory = 87043, steps = 35_740727),
+            since38 = ExUnits(memory = 83987, steps = 34_662865)
           )
         )
     }
@@ -80,8 +80,8 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
         ).runWithBudget()
         assert(
           budget == ScalaCompilerVersion.baseline(
-            pre38 = ExUnits(memory = 108451, steps = 43_455561),
-            since38 = ExUnits(memory = 105395, steps = 42_377699)
+            pre38 = ExUnits(memory = 104723, steps = 42_618565),
+            since38 = ExUnits(memory = 101667, steps = 41_540703)
           )
         )
     }
@@ -93,8 +93,8 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
         ).runWithBudget()
         assert(
           budget == ScalaCompilerVersion.baseline(
-            pre38 = ExUnits(memory = 171521, steps = 57_863333),
-            since38 = ExUnits(memory = 168465, steps = 56_785471)
+            pre38 = ExUnits(memory = 170921, steps = 57_767333),
+            since38 = ExUnits(memory = 167865, steps = 56_689471)
           )
         )
     }
@@ -106,8 +106,8 @@ class AuctionValidatorTest extends AnyFunSuite, ScalusTest {
         ).runWithBudget()
         assert(
           budget == ScalaCompilerVersion.baseline(
-            pre38 = ExUnits(memory = 151847, steps = 47_592180),
-            since38 = ExUnits(memory = 148791, steps = 46_514318)
+            pre38 = ExUnits(memory = 148119, steps = 46_755184),
+            since38 = ExUnits(memory = 145063, steps = 45_677322)
           )
         )
     }

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/betting/BettingTransactionTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/betting/BettingTransactionTest.scala
@@ -289,7 +289,7 @@ class BettingTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, joinTx, betUtxo.input)
         assert(result.isSuccess)
         assert(
-          result.budget == (ExUnits(memory = 162223, steps = 62_515930))
+          result.budget == (ExUnits(memory = 159395, steps = 61_822934))
         )
 
         provider.setSlot(beforeSlot - 1)
@@ -514,7 +514,7 @@ class BettingTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, winTx, joinedBetUtxo.input)
         assert(result.isSuccess)
         assert(
-          result.budget == (ExUnits(memory = 109946, steps = 41_692671))
+          result.budget == (ExUnits(memory = 107118, steps = 40_999675))
         )
 
         provider.setSlot(env.slotConfig.timeToSlot(afterTime))

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/betting/BettingValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/betting/BettingValidatorTest.scala
@@ -84,7 +84,7 @@ class BettingValidatorTest extends AnyFunSuite, ScalusTest:
             println(result)
         assert(result.isSuccess, "Script execution should succeed for initial minting")
         assert(
-          result.budget == (ExUnits(memory = 70831, steps = 23_567977))
+          result.budget == (ExUnits(memory = 68003, steps = 22_874981))
         )
 
     test("Verify that player2 can join an existing bet"):
@@ -159,7 +159,7 @@ class BettingValidatorTest extends AnyFunSuite, ScalusTest:
             println(result)
         assert(result.isSuccess, "Script execution should succeed for player2 joining spending")
         assert(
-          result.budget == (ExUnits(memory = 155006, steps = 59_092034))
+          result.budget == (ExUnits(memory = 152178, steps = 58_399038))
         )
 
     test("Verify that the oracle can announce winner and trigger payout"):
@@ -222,7 +222,7 @@ class BettingValidatorTest extends AnyFunSuite, ScalusTest:
             println(result)
         assert(result.isSuccess, "Script execution should succeed for announce winner spending")
         assert(
-          result.budget == (ExUnits(memory = 107349, steps = 39_681050))
+          result.budget == (ExUnits(memory = 104521, steps = 38_988054))
         )
 
     test("Verify that announcing the winner fails if the bet token is not burned"):
@@ -325,7 +325,7 @@ class BettingValidatorTest extends AnyFunSuite, ScalusTest:
         if result.isFailure then result.logs.foreach(println)
         assert(result.isSuccess, "Reclaim after expiration should succeed")
         assert(
-          result.budget == (ExUnits(memory = 140622, steps = 51_828904))
+          result.budget == (ExUnits(memory = 137794, steps = 51_135908))
         )
 
     test("Verify that reclaim before expiration fails"):

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/escrow/EscrowTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/escrow/EscrowTest.scala
@@ -109,7 +109,7 @@ class EscrowTest extends AnyFunSuite, ScalusTest {
         )
 
         assertResult(
-          ExUnits(memory = 134154, steps = 48_867522)
+          ExUnits(memory = 130726, steps = 48_078526)
         ):
             depositTx.witnessSet.redeemers.get.value.totalExUnits
         val result = provider.submit(depositTx).await()
@@ -214,7 +214,7 @@ class EscrowTest extends AnyFunSuite, ScalusTest {
         )
 
         assertResult(
-          ExUnits(memory = 116600, steps = 41_533374)
+          ExUnits(memory = 113172, steps = 40_744378)
         ):
             payTx.witnessSet.redeemers.get.value.totalExUnits
         val result = provider.submit(payTx).await()
@@ -299,7 +299,7 @@ class EscrowTest extends AnyFunSuite, ScalusTest {
         )
 
         assertResult(
-          ExUnits(memory = 125248, steps = 46_200453)
+          ExUnits(memory = 124417, steps = 47_423078)
         ):
             refundTx.witnessSet.redeemers.get.value.totalExUnits
         val result = provider.submit(refundTx).await()

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/htlc/HtlcTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/htlc/HtlcTest.scala
@@ -61,7 +61,7 @@ class HtlcTest extends AnyFunSuite, ScalusTest {
     }
 
     test(s"HTLC validator size is ${HtlcContract.compiled.script.script.size} bytes") {
-        assert(HtlcContract.compiled.script.script.size == 366)
+        assert(HtlcContract.compiled.script.script.size == 322)
     }
 
     test("VALIDATOR: receiver reveals preimage before timeout") {
@@ -84,8 +84,8 @@ class HtlcTest extends AnyFunSuite, ScalusTest {
         assert(Try(contract(scriptCtx.toData).code).isSuccess)
         val result = contract(scriptCtx.toData).program.evaluateDebug
         assert(result.isSuccess)
-        assert(result.budget == ExUnits(memory = 29355, steps = 12_138878))
-        assert(result.budget.fee == Coin(2569))
+        assert(result.budget == ExUnits(memory = 27127, steps = 11_541882))
+        assert(result.budget.fee == Coin(2398))
     }
 
     test("receiver reveals preimage before timeout") {
@@ -104,7 +104,7 @@ class HtlcTest extends AnyFunSuite, ScalusTest {
           signer = Bob.signer
         )
 
-        assertResult(ExUnits(memory = 29355, steps = 12_138878)):
+        assertResult(ExUnits(memory = 27127, steps = 11_541882)):
             revealTx.witnessSet.redeemers.get.value.totalExUnits
 
         provider.setSlot(beforeSlot)
@@ -185,7 +185,7 @@ class HtlcTest extends AnyFunSuite, ScalusTest {
           signer = Alice.signer
         )
 
-        assertResult(ExUnits(memory = 25922L, steps = 9249707L)):
+        assertResult(ExUnits(memory = 23694L, steps = 8652711L)):
             timeoutTx.witnessSet.redeemers.get.value.totalExUnits
 
         provider.setSlot(afterSlot)

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/pricebet/PricebetValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/pricebet/PricebetValidatorTest.scala
@@ -56,7 +56,7 @@ class PricebetValidatorTest extends AnyFunSuite, ScalusTest {
         assert(
           // Slightly higher than before: the exchange-rate check now uses RationalEq.equals
           // (cross-multiplication) instead of the previous structural equalsData on Rational.
-          joinResult.budget == (ExUnits(memory = 81568, steps = 32_653670))
+          joinResult.budget == (ExUnits(memory = 78440, steps = 31_912674))
         )
     }
 
@@ -132,7 +132,7 @@ class PricebetValidatorTest extends AnyFunSuite, ScalusTest {
         provider.setSlot(beforeSlot)
         val winResult = assertSuccess(provider, winTx, joinedPricebetUtxo._1)
         assert(
-          winResult.budget == (ExUnits(memory = 79915, steps = 28_106800))
+          winResult.budget == (ExUnits(memory = 76787, steps = 27_365804))
         )
     }
 
@@ -281,7 +281,7 @@ class PricebetValidatorTest extends AnyFunSuite, ScalusTest {
         provider.setSlot(updateSlot)
         val updateResult = assertSuccess(provider, updateTx, oracleUtxo._1)
         assert(
-          updateResult.budget == (ExUnits(memory = 61389, steps = 24_034128))
+          updateResult.budget == (ExUnits(memory = 57961, steps = 23_245132))
         )
     }
 

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/simpletransfer/SimpleTransferValidatorTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/simpletransfer/SimpleTransferValidatorTest.scala
@@ -40,7 +40,7 @@ class SimpleTransferValidatorTest extends AnyFunSuite with ScalusTest {
         val res = contract.program.runWithDebug(ctx)
         assert(res.isSuccess, res.logs)
         assert(
-          res.budget == (ExUnits(memory = 94684, steps = 35_275977))
+          res.budget == (ExUnits(memory = 91256, steps = 34_486981))
         )
     }
 
@@ -89,7 +89,7 @@ class SimpleTransferValidatorTest extends AnyFunSuite with ScalusTest {
         val res = contract.program.runWithDebug(ctx)
         assert(res.isSuccess, res.logs)
         assert(
-          res.budget == (ExUnits(memory = 110015, steps = 41_811012))
+          res.budget == (ExUnits(memory = 106587, steps = 41_022016))
         )
     }
 
@@ -119,7 +119,7 @@ class SimpleTransferValidatorTest extends AnyFunSuite with ScalusTest {
         val res = contract.program.runWithDebug(ctx)
         assert(res.isSuccess, res.logs)
         assert(
-          res.budget == (ExUnits(memory = 80263, steps = 27_895837))
+          res.budget == (ExUnits(memory = 76835, steps = 27_106841))
         )
     }
 

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/vault/VaultTransactionTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/vault/VaultTransactionTest.scala
@@ -150,7 +150,7 @@ class VaultTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, withdrawTx, vaultUtxo.input)
         assert(result.isSuccess)
         assert(
-          result.budget == (ExUnits(memory = 102413, steps = 38_755014))
+          result.budget == (ExUnits(memory = 98685, steps = 37_918018))
         )
 
         provider.setSlot(currentSlot)
@@ -247,7 +247,7 @@ class VaultTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, depositTx, vaultUtxo.input)
         assert(result.isSuccess, s"Deposit should succeed: $result")
         assert(
-          result.budget == (ExUnits(memory = 97976, steps = 38_644816))
+          result.budget == (ExUnits(memory = 97076, steps = 38_500816))
         )
 
         assert(provider.submit(depositTx).await().isRight)
@@ -403,7 +403,7 @@ class VaultTransactionTest extends AnyFunSuite, ScalusTest {
         val withdrawResult = runValidator(provider, withdrawTx, vaultUtxo.input)
         assert(withdrawResult.isSuccess, s"Withdraw should succeed: $withdrawResult")
         assert(
-          withdrawResult.budget == (ExUnits(memory = 102413, steps = 38_755014))
+          withdrawResult.budget == (ExUnits(memory = 98685, steps = 37_918018))
         )
 
         provider.setSlot(withdrawSlot)
@@ -450,7 +450,7 @@ class VaultTransactionTest extends AnyFunSuite, ScalusTest {
         val finalizeResult = runValidator(provider, finalizeTx, pendingVaultUtxo.input)
         assert(finalizeResult.isSuccess, s"Finalize should succeed: $finalizeResult")
         assert(
-          finalizeResult.budget == (ExUnits(memory = 96841, steps = 34_363973))
+          finalizeResult.budget == (ExUnits(memory = 96241, steps = 34_267973))
         )
 
         provider.setSlot(finalizeSlot)

--- a/scalus-examples/jvm/src/test/scala/scalus/examples/vesting/VestingTransactionTest.scala
+++ b/scalus-examples/jvm/src/test/scala/scalus/examples/vesting/VestingTransactionTest.scala
@@ -139,7 +139,7 @@ class VestingTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, withdrawTx, lockedUtxo.input)
         assert(result.isSuccess, s"Validator failed: $result")
         assert(
-          result.budget == (ExUnits(memory = 154500, steps = 57_255916))
+          result.budget == (ExUnits(memory = 151072, steps = 56_466920))
         )
 
         val submitResult = provider.submit(withdrawTx).await()
@@ -172,7 +172,7 @@ class VestingTransactionTest extends AnyFunSuite, ScalusTest {
         val result = runValidator(provider, withdrawTx, lockedUtxo.input)
         assert(result.isSuccess, s"Validator failed: $result")
         assert(
-          result.budget == (ExUnits(memory = 185197, steps = 74_033910))
+          result.budget == (ExUnits(memory = 181769, steps = 73_244914))
         )
 
         val submitResult = provider.submit(withdrawTx).await()


### PR DESCRIPTION
## What

`IntrinsicResolver` never dispatched intrinsics on a `PackedSumDataList` receiver — the representation of every lazily-decoded ledger list (`TxInfo.signatories`, or any `.to[List[...]]`-decoded list). `representationNames` mapped that repr only to the name `"PackedSumDataList"`, which has no registry entry, so `List.contains`/`indexOf`/`deleteFirst`/`distinct`/`diff` silently lowered their **generic prelude bodies** (a data-encoded `Some` allocated per element, plus a dead `Eq` closure that `EqStrip` never removed, because stripping only happens when dispatch fires) instead of the `equalsData`-scan intrinsics.

Measured cost of the miss: **+2,528 mem / +644,996 steps** for a single `signatories.contains` (CAPE linear_vesting).

## Fix

`dispatchReprNames` lets a `PackedSumDataList` receiver fall back to the `BuiltinList` provider name (a packed list is viewable as a `BuiltinList` of `Data` by unpacking on demand), **scoped to the `EqStripMethods` family**.

The scoping matters: a broader variant that also routed the spine ops (`head`/`tail`/`isEmpty`/`at`/`drop`) mislabeled element representations — `head`/`at` on a packed `List[ByteString]` returned a still-`Data` value labeled native, a runtime failure in MembershipToken (`Blake2b_256` applied to `VCon(Data)`) — and regressed degenerate micro cases, so it was backed out. The Eq-family providers return scalars or relabeled Data lists, so no mislabeling is possible. Re-enabling the spine ops once element-repr labeling is fixed is recorded as T17 in `docs/internal/CODEGEN_IMPROVEMENT_PLAN.md`.

## Measured effect (re-pins against master's own baseline)

74 expectations re-pinned: 59 ExUnits + 1 fee + 2 script sizes measured on Scala 3.3.8 (pre38), and the 12 since38 baselines in Clausify/Knights/Auction re-measured under `++3.8.4` (each since38 delta matches its pre38 delta exactly).

**73 of 74 are strict improvements**:
- all 22 moved ListTest pins (`distinct` nearly halves, e.g. mem 25,309 → 14,461)
- HelloCardano −13.7% mem, script 316 → 271 B
- HTLC script 366 → 322 B
- Auction −2.4..−4.1% mem, Vault −3.6% mem, Knights/Clausify −1.7%

The one mixed move is **Escrow Refund**: mem −831, steps +1,222,625 (≈ +40 lovelace net on that path) — consistent with the `equalsData` scan trading the generic body's per-element allocations for `equalsData`'s large constant CPU cost when the match sits deeper in the list; Escrow's other two paths improve.

## Verification

- Full `jvm/test` green on 3.3.8
- `scalusJVM/test` + `scalusExamplesJVM/test` green on `++3.8.4` (the `ci-jvm-next` leg)
- `mima` clean, `scalafmtAll` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)
