### PR TITLE
feat(stream): coverage-aware hub, chain-follower seam, and a Blockfrost polling follower (M2 groundwork)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -848,7 +848,15 @@ lazy val scalusCardanoLedger = crossProject(JSPlatform, JVMPlatform)
         // so the default evaluation path skips hex encoding entirely.
         ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "scalus.cardano.ledger.PlutusScriptEvaluator#DefaultImpl.evalScript"
-        )
+        ),
+        // TEMPORARY, and meant to be removed. The streaming facade is declared out of the
+        // cross-language interop surface — it has two higher-kinded parameters, context bounds and
+        // macro subscribe methods, none of it reachable from Java, Kotlin or JS — and is
+        // deliberately unfrozen for one or two releases while the Blockfrost and Ogmios providers
+        // shake its shapes out. Freeze it after that and delete this filter.
+        // Without it, the first release that ships this package freezes it: it is absent from the
+        // previous published artifact today, which is the only reason MiMa is currently silent.
+        ProblemFilters.exclude[Problem]("scalus.cardano.node.stream.*")
       ),
       crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,

--- a/build.sbt
+++ b/build.sbt
@@ -849,14 +849,15 @@ lazy val scalusCardanoLedger = crossProject(JSPlatform, JVMPlatform)
         ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "scalus.cardano.ledger.PlutusScriptEvaluator#DefaultImpl.evalScript"
         ),
-        // TEMPORARY, and meant to be removed. The streaming facade is declared out of the
-        // cross-language interop surface — it has two higher-kinded parameters, context bounds and
-        // macro subscribe methods, none of it reachable from Java, Kotlin or JS — and is
-        // deliberately unfrozen for one or two releases while the Blockfrost and Ogmios providers
-        // shake its shapes out. Freeze it after that and delete this filter.
-        // Without it, the first release that ships this package freezes it: it is absent from the
-        // previous published artifact today, which is the only reason MiMa is currently silent.
-        ProblemFilters.exclude[Problem]("scalus.cardano.node.stream.*")
+        // The streaming hub's internals churn while the provider implementations are built —
+        // `AppliedBlock` has already gained a field. Scoped to `.internal` on purpose: CLAUDE.md
+        // reserves wildcards for wholly-internal packages, and a wildcard over the whole
+        // `...node.stream` package would also silence a genuine break in the public facade
+        // (`BlockchainStreamProvider`, `StreamCapabilities`, `SubscriptionOptions`, …).
+        // The proposal does declare the public facade unfrozen for a release or two as well; when
+        // a break there is actually needed, it gets its own filter naming the symbol, so the thing
+        // being broken is visible in review rather than pre-authorised in bulk.
+        ProblemFilters.exclude[Problem]("scalus.cardano.node.stream.internal.*")
       ),
       crossScalaVersions := Seq(scala3LtsVersion, scala3NextVersion),
       scalacOptions ++= commonScalacOptions,

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamCapabilities.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamCapabilities.scala
@@ -28,22 +28,36 @@ object SubscriptionKind {
     val all: Set[SubscriptionKind] = Set(Utxo, Transaction, Block)
 }
 
-/** What it costs a provider to examine a block it was not asked about.
+/** What happens to a subscription the provider cannot serve from an index.
   *
-  * The distinction is not how clever the matching is — it is whether the provider already holds the
-  * block's contents. An in-memory ledger, a chain-sync follower and a gRPC stream all see every
-  * transaction anyway, so a subscription that matches everything costs them nothing beyond the
-  * fan-out they already do. A REST provider whose cheap path is per-address endpoints has to fetch
-  * the block and then a UTxO set per transaction in it, which is the difference between a handful
-  * of requests a day and a spent quota.
+  * The distinction between the first two is not how clever the matching is — it is whether the
+  * provider already holds the block's contents. An in-memory ledger, a chain-sync follower and a
+  * gRPC stream all see every transaction anyway, so a subscription that matches everything costs
+  * them nothing beyond the fan-out they already do. A REST provider whose cheap path is per-address
+  * endpoints has to fetch the block and then a UTxO set per transaction in it, which is the
+  * difference between a handful of requests a day and a spent quota.
+  *
+  * The third is a different kind of answer, and it needs to be stated rather than approximated by
+  * the second: a provider built entirely out of per-source lookups has no request sequence that
+  * would answer "every transaction" at all. Calling that `Metered` would let a caller consent, via
+  * `allowUnindexedScan`, to something that cannot happen — and the subscription would then be
+  * accepted and deliver nothing, forever, with no error. Consenting to an impossibility is worse
+  * than being refused.
   */
-enum ScanCost {
+enum ScanSupport {
 
     /** The provider already has every block's contents; scanning adds nothing. */
     case Free
 
-    /** Examining a block the provider would not otherwise fetch costs it real requests. */
+    /** Examining a block the provider would not otherwise fetch costs it real requests, so a caller
+      * must opt in with `SubscriptionOptions.allowUnindexedScan`.
+      */
     case Metered
+
+    /** The provider cannot examine a block it was not asked about at all, so it serves exactly what
+      * [[StreamCapabilities.pushdown]] covers and refuses everything else.
+      */
+    case Unsupported
 }
 
 /** How far back a provider can start a subscription.
@@ -96,7 +110,7 @@ enum ReplaySupport {
 case class StreamCapabilities(
     kinds: Set[SubscriptionKind],
     pushdown: Set[PushdownKind],
-    scanning: ScanCost,
+    scanning: ScanSupport,
     replay: ReplaySupport,
     rollbackHorizon: Option[Int],
     maxConfirmations: Option[Int],
@@ -116,7 +130,7 @@ object StreamCapabilities {
     ): StreamCapabilities = StreamCapabilities(
       kinds = kinds,
       pushdown = PushdownKind.all,
-      scanning = ScanCost.Free,
+      scanning = ScanSupport.Free,
       replay = replay,
       rollbackHorizon = rollbackHorizon,
       maxConfirmations = None,

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamCapabilities.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamCapabilities.scala
@@ -22,10 +22,22 @@ enum SubscriptionKind {
     case Utxo
     case Transaction
     case Block
+
+    /** Following one transaction from the mempool into a block and back out again.
+      *
+      * Declared separately from [[Transaction]] because it is a different question. A provider that
+      * observes only the sources it was asked to watch can serve transaction *subscriptions* — it
+      * matches what it fetched — while having no way to answer "what happened to this particular
+      * hash", because a transaction it was never asked about is a transaction it never looked up.
+      * Left undeclared, such a provider reports `Pending` forever for a transaction that is
+      * confirmed on chain, which is worse than refusing: the subscriber has no way to tell a
+      * transaction that has not landed from one the provider never watched.
+      */
+    case TransactionStatus
 }
 
 object SubscriptionKind {
-    val all: Set[SubscriptionKind] = Set(Utxo, Transaction, Block)
+    val all: Set[SubscriptionKind] = Set(Utxo, Transaction, Block, TransactionStatus)
 }
 
 /** What happens to a subscription the provider cannot serve from an index.

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamingEmulator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamingEmulator.scala
@@ -159,6 +159,7 @@ class StreamingEmulator(val emulator: EmulatorBase, val securityParam: Int = 0)
     def subscribeTransactionStatus[C[_]: ScalusAsyncStreamAdapter](
         txHash: TransactionHash
     ): C[TransactionStatus] = {
+        hub.require(SubscriptionRequest.TransactionStatus(txHash))
         val id = hub.nextSubscriptionId()
         val mailbox =
             Mailbox.latestValue[TransactionStatus](() => hub.unregisterTxStatus(txHash, id))
@@ -235,7 +236,11 @@ object StreamingEmulator {
       * the declared horizon so the hub and the classifier agree on the depth.
       */
     def capabilities(securityParam: Int): StreamCapabilities = StreamCapabilities(
-      kinds = Set(SubscriptionKind.Utxo, SubscriptionKind.Transaction),
+      kinds = Set(
+        SubscriptionKind.Utxo,
+        SubscriptionKind.Transaction,
+        SubscriptionKind.TransactionStatus
+      ),
       pushdown = PushdownKind.all,
       scanning = ScanSupport.Free,
       replay = ReplaySupport.NoReplay,

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamingEmulator.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/StreamingEmulator.scala
@@ -237,7 +237,7 @@ object StreamingEmulator {
     def capabilities(securityParam: Int): StreamCapabilities = StreamCapabilities(
       kinds = Set(SubscriptionKind.Utxo, SubscriptionKind.Transaction),
       pushdown = PushdownKind.all,
-      scanning = ScanCost.Free,
+      scanning = ScanSupport.Free,
       replay = ReplaySupport.NoReplay,
       rollbackHorizon = if securityParam > 0 then Some(securityParam) else None,
       maxConfirmations = None,

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionOptions.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionOptions.scala
@@ -25,6 +25,14 @@ case class SubscriptionOptions(
     /** Seed the subscription from the provider's snapshot view: emit a synthetic
       * [[UtxoEvent.Created]] for every UTxO already matching the query, before live deltas start.
       * `false` yields a live-only stream. Irrelevant for non-UTxO subscriptions.
+      *
+      * Not purely a matter of taste on a provider that fetches per source rather than whole blocks.
+      * Such a provider only observes a query's sources from the point it is told to watch them, and
+      * the block spanning that moment may already have been assembled without them. The seed is
+      * what covers that block — it is a snapshot of state *after* it. Turning the seed off
+      * therefore accepts that events in that one block may never be delivered, with no error and no
+      * `Idle`. A live-only subscriber that cannot tolerate this should subscribe, then reconcile
+      * against its own `findUtxos` read.
       */
     includeExistingUtxos: Boolean = true,
 

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionSupport.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionSupport.scala
@@ -8,15 +8,22 @@ enum SubscriptionRequest {
     case Transaction(query: TransactionQuery, opts: SubscriptionOptions)
     case Block(query: BlockQuery, opts: SubscriptionOptions)
 
+    /** Following one transaction's status. Carries no options: latest-value streams take none, as
+      * [[SubscriptionOptions]] explains.
+      */
+    case TransactionStatus(txHash: scalus.cardano.ledger.TransactionHash)
+
     def options: SubscriptionOptions = this match
-        case Utxo(_, o)        => o
-        case Transaction(_, o) => o
-        case Block(_, o)       => o
+        case Utxo(_, o)           => o
+        case Transaction(_, o)    => o
+        case Block(_, o)          => o
+        case _: TransactionStatus => SubscriptionOptions()
 
     def kind: SubscriptionKind = this match
-        case _: Utxo        => SubscriptionKind.Utxo
-        case _: Transaction => SubscriptionKind.Transaction
-        case _: Block       => SubscriptionKind.Block
+        case _: Utxo              => SubscriptionKind.Utxo
+        case _: Transaction       => SubscriptionKind.Transaction
+        case _: Block             => SubscriptionKind.Block
+        case _: TransactionStatus => SubscriptionKind.TransactionStatus
 }
 
 /** The verdict on a subscription request. */
@@ -103,6 +110,10 @@ object SubscriptionSupport {
                     // looking up a source cannot serve one at all. `isIndexed` answers `true` for
                     // blocks because there is nothing to *scan*, which is the opposite question.
                     request match
+                        case _: SubscriptionRequest.TransactionStatus =>
+                            // Nothing to replay: the status of a transaction is a current fact,
+                            // not a history the subscriber can resume through.
+                            None
                         case _: SubscriptionRequest.Block =>
                             Some(
                               Unsupported(
@@ -145,6 +156,9 @@ object SubscriptionSupport {
             case SubscriptionRequest.Transaction(q, _) => indexedTxQuery(q, pushdown)
             // Every block is a match, so there is nothing to look up and nothing to scan for.
             case SubscriptionRequest.Block(_, _) => true
+            // A hash is the most direct lookup there is; a provider that serves this kind at all
+            // serves it without scanning.
+            case _: SubscriptionRequest.TransactionStatus => true
 
     private def indexedUtxoQuery(query: UtxoQuery, pushdown: Set[PushdownKind]): Boolean =
         query match

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionSupport.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/SubscriptionSupport.scala
@@ -130,8 +130,14 @@ object SubscriptionSupport {
                 // there is nothing for the caller to consent to. Making it demand
                 // `allowUnindexedScan` would refuse "watch every transaction" on an in-memory
                 // ledger, where that is the cheapest thing you can ask for.
-                case ScanCost.Free    => Indexed
-                case ScanCost.Metered => Unindexed
+                case ScanSupport.Free    => Indexed
+                case ScanSupport.Metered => Unindexed
+                case ScanSupport.Unsupported =>
+                    Unsupported(
+                      "this provider serves only subscriptions it can look up by query source " +
+                          s"(${caps.pushdown.mkString(", ")}); it has no way to examine a block " +
+                          "it was not asked about, so this cannot be served at any price"
+                    )
 
     private def isIndexed(request: SubscriptionRequest, pushdown: Set[PushdownKind]): Boolean =
         request match

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/AppliedBlock.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/AppliedBlock.scala
@@ -55,7 +55,15 @@ object BlockCoverage {
         probed.contains(source) || (source match
             case UtxoSource.Or(l, r)  => coveredBy(l, probed) && coveredBy(r, probed)
             case UtxoSource.And(l, r) => coveredBy(l, probed) || coveredBy(r, probed)
-            case _                    => false)
+            // Probing a superset of the inputs asked about does cover them, so this is a
+            // membership test rather than set equality — matching how `SubscriptionHub`'s
+            // `SpendsInput` branch answers the same underlying question.
+            case UtxoSource.FromInputs(wanted) =>
+                probed.exists {
+                    case UtxoSource.FromInputs(have) => wanted.subsetOf(have)
+                    case _                           => false
+                }
+            case _ => false)
 }
 
 /** A block as the subscription hub consumes it.

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/AppliedBlock.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/AppliedBlock.scala
@@ -1,6 +1,7 @@
 package scalus.cardano.node.stream.internal
 
 import scalus.cardano.ledger.{Block, Transaction, Utxos}
+import scalus.cardano.node.UtxoSource
 import scalus.cardano.node.stream.{BlockNo, ChainPoint}
 
 /** One applied transaction, with its UTxO effects already resolved.
@@ -14,16 +15,84 @@ case class AppliedTransaction(tx: Transaction, created: Utxos, spent: Utxos) {
     def txHash: scalus.cardano.ledger.TransactionHash = tx.id
 }
 
+/** What the provider actually examined when it produced an [[AppliedBlock]].
+  *
+  * A provider that holds the whole block can answer any subscription from it. A metered provider
+  * cannot afford to: Blockfrost's cheap path is per-address and per-asset endpoints, so what it
+  * learns about a block is only ever "what these sources did in it", and it must say so.
+  *
+  * The distinction is load-bearing rather than informational. The hub delivers a block to a
+  * subscription and advances that subscription's watermark past it in the same step, so handing it
+  * a block that did not cover a subscription would tell that subscriber "nothing here for you" — as
+  * an [[scalus.cardano.node.stream.UtxoEvent.Idle]], no less — and then make the real events for
+  * that height undeliverable, because the watermark has moved on. Silently.
+  */
+enum BlockCoverage {
+
+    /** The provider holds the whole block and can answer any query from it. */
+    case Complete
+
+    /** The provider examined only these sources. A subscription is covered when its query can be
+      * answered from them — see [[BlockCoverage.covers]].
+      */
+    case Sources(sources: Set[UtxoSource])
+}
+
+object BlockCoverage {
+
+    /** Whether a block with this coverage is authoritative for a query.
+      *
+      * The recursion mirrors `SubscriptionSupport.isIndexed`, and for the same reasons: a union is
+      * covered only if every arm is, because the events we would miss are exactly the ones the
+      * uncovered arm would have found; an intersection needs just one covered arm, because that
+      * arm's results contain every candidate and the other arm post-filters data already in hand.
+      */
+    def covers(coverage: BlockCoverage, source: UtxoSource): Boolean = coverage match
+        case Complete        => true
+        case Sources(probed) => coveredBy(source, probed)
+
+    private def coveredBy(source: UtxoSource, probed: Set[UtxoSource]): Boolean =
+        probed.contains(source) || (source match
+            case UtxoSource.Or(l, r)  => coveredBy(l, probed) && coveredBy(r, probed)
+            case UtxoSource.And(l, r) => coveredBy(l, probed) || coveredBy(r, probed)
+            case _                    => false)
+}
+
 /** A block as the subscription hub consumes it.
   *
   * `block` is the raw ledger block when the provider has one. Providers that synthesise blocks — an
   * emulator applying one transaction at a time — have nothing truthful to put here, which is why it
   * is optional and why such providers declare that they do not serve `Block` subscriptions rather
   * than fabricating a header.
+  *
+  * ## The contract for partial coverage
+  *
+  * A provider producing anything other than [[BlockCoverage.Complete]] owes the hub two things.
+  *
+  *   - **One block per height, carrying the union of every source probed at that height** — not one
+  *     block per watcher. A query spanning two sources is covered only by a block that probed both
+  *     (a union is as covered as its worst arm), so splitting a height across per-watcher blocks
+  *     would leave such a subscription permanently uncovered and silent.
+  *   - **Every height examined, whether or not it matched anything.** An empty `txs` with the right
+  *     coverage is how a provider says "I looked here for these sources and there was nothing",
+  *     which is both what makes `Idle` truthful and what keeps watermarks tracking the tip. A
+  *     provider that reported only the heights it found matches in would let its subscriptions fall
+  *     arbitrarily far behind the retention window and lose events to pruning.
+  *
+  * Heights are applied in ascending order and each is applied once — `SubscriptionHub.applyBlock`
+  * takes the block's height as the new tip unconditionally, so it has always required this.
+  *
+  * **Not yet supported: backfill.** A provider that runs out of request budget mid-height and wants
+  * to come back for the sources it skipped would have to re-report a height it has already applied,
+  * and there is no representation for that: `recent` is ordered by height and a subscription's
+  * progress is a single watermark. Such a provider must instead defer the *whole* height until it
+  * can cover everything it has subscriptions for. Lifting this needs per-height observation sets
+  * and is a deliberate design step, not an implementation detail — see the M2 plan.
   */
 case class AppliedBlock(
     point: ChainPoint,
     blockNo: BlockNo,
     txs: Seq[AppliedTransaction],
-    block: Option[Block] = None
+    block: Option[Block] = None,
+    coverage: BlockCoverage = BlockCoverage.Complete
 )

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
@@ -84,12 +84,18 @@ private[stream] final class BlockfrostChainFollower(
 )(using ec: ExecutionContext)
     extends ChainFollower {
 
-    private val mailbox = Mailbox.delta[ChainEvent]()
+    /** Bounded for the same reason subscriber buffers are: an unbounded producer queue turns a
+      * driver that cannot keep up into an OOM naming nothing, instead of a failure naming this
+      * feed. Each entry holds a whole `AppliedBlock`, and the driver is the only consumer and pulls
+      * in a loop, so reaching this bound at all means something is already wrong.
+      */
+    private val mailbox = Mailbox.delta[ChainEvent](BlockfrostChainFollower.eventBufferBound)
 
     // Guarded by `this`: mutated from the poll loop and from `watch` on the caller's thread.
     private var watched: Set[UtxoSource] = Set.empty
     private var last: Option[BlockRef] = None
     private var stopped = false
+    private var started = false
 
     override def events: ScalusAsyncSource[ChainEvent] = mailbox
 
@@ -104,12 +110,17 @@ private[stream] final class BlockfrostChainFollower(
 
     /** Start polling. The loop is a `Future` chain, not a thread, so it works on Scala.js too. */
     def start(): Unit = {
-        api.latestBlock().onComplete {
-            case Success(tip) =>
-                synchronized { last = Some(tip) }
-                loop()
-            case Failure(t) => mailbox.fail(t)
+        val begin = synchronized {
+            if started || stopped then false
+            else { started = true; true }
         }
+        if begin then
+            api.latestBlock().onComplete {
+                case Success(tip) =>
+                    synchronized { last = Some(tip) }
+                    loop()
+                case Failure(t) => mailbox.fail(t)
+            }
     }
 
     private def loop(): Unit = if !isStopped then
@@ -144,17 +155,32 @@ private[stream] final class BlockfrostChainFollower(
             acc.flatMap(_ => if isStopped then Future.unit else f(a))
         )
 
+    /** Like `Future.sequence`, but one request at a time.
+      *
+      * Deliberately not concurrent. Rate limiting is the *expected* steady state for a metered
+      * backend, and firing a block's per-address and per-transaction requests all at once maximises
+      * the chance of provoking the 429 this follower has no way to survive. Latency is the cheaper
+      * thing to spend here.
+      */
+    private def sequentiallyCollect[A, B](items: Seq[A])(f: A => Future[B]): Future[Seq[B]] =
+        items.foldLeft(Future.successful(Vector.empty[B]))((acc, a) =>
+            acc.flatMap(bs => f(a).map(bs :+ _))
+        )
+
     private def emitBlock(block: BlockRef): Future[Unit] = {
-        val sources = synchronized(watched)
-        val addresses = sources.collect { case UtxoSource.FromAddress(a) => a }
-        val hashes = Future
-            .sequence(
-              addresses.toSeq.map(a => api.addressTransactionsIn(a, block.blockNo, block.blockNo))
-            )
+        // Only address sources are probed, so only address sources may be claimed. Declaring the
+        // whole watched set would tell the hub this block is authoritative for, say, a FromAsset
+        // subscription that was never looked up — which is precisely the silent event loss
+        // BlockCoverage exists to prevent, committed by the thing that reports the coverage.
+        val addresses = synchronized(watched).collect { case UtxoSource.FromAddress(a) => a }
+        val probed: Set[UtxoSource] = addresses.map(UtxoSource.FromAddress(_))
+        val hashes = sequentiallyCollect(addresses.toSeq)(a =>
+            api.addressTransactionsIn(a, block.blockNo, block.blockNo)
+        )
             // One transaction can touch several watched addresses; the hub must see it once.
             .map(_.flatten.distinct)
         hashes
-            .flatMap(hs => Future.sequence(hs.map(api.transaction)))
+            .flatMap(hs => sequentiallyCollect(hs)(api.transaction))
             .map { observed =>
                 val applied = observed.map(o => AppliedTransaction(o.tx, o.created, o.spent))
                 mailbox.offer(
@@ -166,11 +192,17 @@ private[stream] final class BlockfrostChainFollower(
                       block = None,
                       // Every height is reported, matches or not, and always with the full set of
                       // sources probed at it — both halves of AppliedBlock's contract.
-                      coverage = BlockCoverage.Sources(sources)
+                      coverage = BlockCoverage.Sources(probed)
                     )
                   )
                 )
                 synchronized { last = Some(block) }
             }
     }
+}
+
+private[stream] object BlockfrostChainFollower {
+
+    /** Blocks the follower may run ahead of the driver by. See the mailbox's own note. */
+    val eventBufferBound: Int = 256
 }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
@@ -97,9 +97,20 @@ private[stream] final class BlockfrostChainFollower(
     private var stopped = false
     private var started = false
 
+    /** The highest height whose set of probed sources has already been decided.
+      *
+      * Updated in the same critical section that reads `watched`, which is what lets `watch` report
+      * a position a caller can rely on: a block already being assembled has a height at or below
+      * this, and every block assembled afterwards sees the new source set.
+      */
+    private var committed: BlockNo = 0L
+
     override def events: ScalusAsyncSource[ChainEvent] = mailbox
 
-    override def watch(sources: Set[UtxoSource]): Unit = synchronized { watched = sources }
+    override def watch(sources: Set[UtxoSource]): BlockNo = synchronized {
+        watched = sources
+        committed
+    }
 
     override def close(): Unit = {
         synchronized { stopped = true }
@@ -117,7 +128,12 @@ private[stream] final class BlockfrostChainFollower(
         if begin then
             api.latestBlock().onComplete {
                 case Success(tip) =>
-                    synchronized { last = Some(tip) }
+                    synchronized {
+                        last = Some(tip)
+                        // Nothing below the tip is ever emitted, so this is the first height a
+                        // subscription could be observed from.
+                        committed = tip.blockNo
+                    }
                     loop()
                 case Failure(t) => mailbox.fail(t)
             }
@@ -172,7 +188,13 @@ private[stream] final class BlockfrostChainFollower(
         // whole watched set would tell the hub this block is authoritative for, say, a FromAsset
         // subscription that was never looked up — which is precisely the silent event loss
         // BlockCoverage exists to prevent, committed by the thing that reports the coverage.
-        val addresses = synchronized(watched).collect { case UtxoSource.FromAddress(a) => a }
+        val addresses = synchronized {
+            // Fixing this block's source set and recording that it is fixed must be one step; a
+            // `watch` landing between them would be told this height was already covered by the
+            // new set when it was not.
+            committed = block.blockNo
+            watched.collect { case UtxoSource.FromAddress(a) => a }
+        }
         val probed: Set[UtxoSource] = addresses.map(UtxoSource.FromAddress(_))
         val hashes = sequentiallyCollect(addresses.toSeq)(a =>
             api.addressTransactionsIn(a, block.blockNo, block.blockNo)

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
@@ -97,26 +97,30 @@ private[stream] final class BlockfrostChainFollower(
     private var stopped = false
     private var started = false
 
-    /** The highest height whose set of probed sources has already been decided.
+    /** The block whose set of probed sources was most recently decided.
       *
       * Two assignment sites, with different arguments for why each is safe:
       *
       *   - `emitBlock` updates it in the same critical section that reads `watched`, which is what
       *     lets `watch` report a position a caller can rely on: a block already being assembled has
-      *     a height at or below this, and every block assembled afterwards sees the new set.
+      *     been recorded here, and every block assembled afterwards sees the new set.
       *   - `start` seeds it from the chain tip. That one rests not on the lock but on the backend's
       *     `/blocks/{hash}/next` contract — nothing at or below the starting tip is ever emitted,
       *     so nothing at or below it needs covering.
       *
-      * Note this is deliberately ahead of `last`, which is the actual delivery cursor: sources are
-      * fixed before any of the block's requests are issued, so a block can be counted here while
-      * none of its transactions have been fetched yet.
+      * Kept as a whole [[BlockRef]] rather than a point so the height is available for the
+      * monotonicity guard, while `watch` returns the point — see [[ChainFollower.watch]] for why a
+      * height alone cannot name a position across a fork.
+      *
+      * Deliberately ahead of `last`, which is the actual delivery cursor: sources are fixed before
+      * any of the block's requests are issued, so a block can be recorded here while none of its
+      * transactions have been fetched yet.
       */
-    private var committed: BlockNo = 0L
+    private var committed: Option[BlockRef] = None
 
     override def events: ScalusAsyncSource[ChainEvent] = mailbox
 
-    override def watch(sources: Set[UtxoSource]): BlockNo = synchronized {
+    override def watch(sources: Set[UtxoSource]): ChainPoint = synchronized {
         // A stopped follower will never assemble another block, so a position promising coverage
         // above it would be a lie the caller has no way to detect: it would register, and then
         // wait forever with no events, no Idle and no error.
@@ -126,7 +130,7 @@ private[stream] final class BlockfrostChainFollower(
                   "registered against it could never be covered"
             )
         watched = sources
-        committed
+        committed.map(_.point).getOrElse(ChainPoint.origin)
     }
 
     override def close(): Unit = {
@@ -154,9 +158,9 @@ private[stream] final class BlockfrostChainFollower(
                 case Success(tip) =>
                     synchronized {
                         last = Some(tip)
-                        // Nothing below the tip is ever emitted, so this is the first height a
+                        // Nothing below the tip is ever emitted, so this is the first position a
                         // subscription could be observed from.
-                        committed = tip.blockNo
+                        committed = Some(tip)
                     }
                     loop()
                 case Failure(t) => mailbox.fail(t)
@@ -219,9 +223,11 @@ private[stream] final class BlockfrostChainFollower(
             // new set when it was not.
             // Monotonic: a backend that serves a stale `/blocks/{hash}/next` page — a lagging
             // replica is the realistic case — must not be able to drag this backwards, or a
-            // `watch` landing next would be handed a position implying coverage of heights that
-            // were already assembled with the old source set.
-            committed = math.max(committed, block.blockNo)
+            // `watch` landing next would be handed a position implying coverage of blocks that
+            // were already assembled with the old source set. This follower never rolls back (it
+            // fails instead), so monotonicity here is unconditional; one that did would have to
+            // lower it deliberately, as ChainFollower.watch describes.
+            if committed.forall(_.blockNo <= block.blockNo) then committed = Some(block)
             watched.collect { case UtxoSource.FromAddress(a) => a }
         }
         val probed: Set[UtxoSource] = addresses.map(UtxoSource.FromAddress(_))

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
@@ -99,15 +99,32 @@ private[stream] final class BlockfrostChainFollower(
 
     /** The highest height whose set of probed sources has already been decided.
       *
-      * Updated in the same critical section that reads `watched`, which is what lets `watch` report
-      * a position a caller can rely on: a block already being assembled has a height at or below
-      * this, and every block assembled afterwards sees the new source set.
+      * Two assignment sites, with different arguments for why each is safe:
+      *
+      *   - `emitBlock` updates it in the same critical section that reads `watched`, which is what
+      *     lets `watch` report a position a caller can rely on: a block already being assembled has
+      *     a height at or below this, and every block assembled afterwards sees the new set.
+      *   - `start` seeds it from the chain tip. That one rests not on the lock but on the backend's
+      *     `/blocks/{hash}/next` contract — nothing at or below the starting tip is ever emitted,
+      *     so nothing at or below it needs covering.
+      *
+      * Note this is deliberately ahead of `last`, which is the actual delivery cursor: sources are
+      * fixed before any of the block's requests are issued, so a block can be counted here while
+      * none of its transactions have been fetched yet.
       */
     private var committed: BlockNo = 0L
 
     override def events: ScalusAsyncSource[ChainEvent] = mailbox
 
     override def watch(sources: Set[UtxoSource]): BlockNo = synchronized {
+        // A stopped follower will never assemble another block, so a position promising coverage
+        // above it would be a lie the caller has no way to detect: it would register, and then
+        // wait forever with no events, no Idle and no error.
+        if stopped then
+            throw new IllegalStateException(
+              "this follower is closed and will produce no further blocks; a subscription " +
+                  "registered against it could never be covered"
+            )
         watched = sources
         committed
     }
@@ -117,7 +134,14 @@ private[stream] final class BlockfrostChainFollower(
         mailbox.close()
     }
 
-    private def isStopped: Boolean = synchronized(stopped)
+    /** Stopped, or pointless to continue.
+      *
+      * A bounded mailbox fails its consumer on overflow and then silently discards everything
+      * offered afterwards, so without this check the loop keeps polling — one `/blocks/next` per
+      * interval plus a request per watched address per block, against a metered daily quota — for a
+      * feed nobody can ever read again.
+      */
+    private def isStopped: Boolean = synchronized(stopped) || mailbox.isClosed
 
     /** Start polling. The loop is a `Future` chain, not a thread, so it works on Scala.js too. */
     def start(): Unit = {
@@ -144,6 +168,7 @@ private[stream] final class BlockfrostChainFollower(
             case Success(_) => loop()
             case Failure(t) => mailbox.fail(t)
         }
+    else close()
 
     private def poll(): Future[Unit] = {
         val from = synchronized(last)
@@ -192,7 +217,11 @@ private[stream] final class BlockfrostChainFollower(
             // Fixing this block's source set and recording that it is fixed must be one step; a
             // `watch` landing between them would be told this height was already covered by the
             // new set when it was not.
-            committed = block.blockNo
+            // Monotonic: a backend that serves a stale `/blocks/{hash}/next` page — a lagging
+            // replica is the realistic case — must not be able to drag this backwards, or a
+            // `watch` landing next would be handed a position implying coverage of heights that
+            // were already assembled with the old source set.
+            committed = math.max(committed, block.blockNo)
             watched.collect { case UtxoSource.FromAddress(a) => a }
         }
         val probed: Set[UtxoSource] = addresses.map(UtxoSource.FromAddress(_))

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/BlockfrostChainFollower.scala
@@ -1,0 +1,176 @@
+package scalus.cardano.node.stream.internal
+
+import scalus.cardano.address.Address
+import scalus.cardano.infra.ResyncRequiredException
+import scalus.cardano.ledger.{Transaction, TransactionHash, Utxos}
+import scalus.cardano.node.UtxoSource
+import scalus.cardano.node.stream.{BlockNo, ChainPoint, ScalusAsyncSource}
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
+
+/** A block as the follower identifies it. */
+private[stream] case class BlockRef(point: ChainPoint, blockNo: BlockNo)
+
+/** A transaction the follower observed, with its UTxO effects resolved.
+  *
+  * `spent` is the *resolved* consumed outputs — Blockfrost's `/txs/{hash}/utxos` returns the
+  * address and value of each input, not just its reference, which is exactly what the hub's
+  * contract needs and what a subscriber watching an address cannot reconstruct on its own.
+  */
+private[stream] case class ObservedTransaction(tx: Transaction, created: Utxos, spent: Utxos)
+
+/** The slice of Blockfrost this follower needs.
+  *
+  * Narrow on purpose: it is the seam a fake is written against, so the polling logic — which is the
+  * part with the interesting failure modes — is testable without HTTP, a clock or a key.
+  */
+private[stream] trait BlockfrostChainApi {
+
+    /** `GET /blocks/latest`. Used once, to decide where "the tip" is at subscription time. */
+    def latestBlock(): Future[BlockRef]
+
+    /** `GET /blocks/{hash}/next` — the blocks that follow `hash`, in ascending order.
+      *
+      * `None` means Blockfrost does not have `hash` on its chain any more (a 404), which is how a
+      * reorg announces itself here: the block we last reported has been orphaned. Detecting it
+      * costs nothing beyond the poll we were making anyway, which is why this is the poll rather
+      * than `/blocks/latest`.
+      */
+    def blocksAfter(block: BlockRef): Future[Option[Seq[BlockRef]]]
+
+    /** `GET /addresses/{address}/transactions?from=&to=` — the address's transactions within a
+      * block-height range, which is what makes an address subscription one request per block
+      * instead of a scan.
+      */
+    def addressTransactionsIn(
+        address: Address,
+        from: BlockNo,
+        to: BlockNo
+    ): Future[Seq[TransactionHash]]
+
+    /** The transaction body plus its resolved UTxO effects. */
+    def transaction(hash: TransactionHash): Future[ObservedTransaction]
+}
+
+/** Polls Blockfrost and reports what it finds as [[ChainEvent]]s.
+  *
+  * ## Cost
+  *
+  * One `/blocks/{hash}/next` per poll, plus — per new block — one `/addresses/{a}/transactions` per
+  * watched address and two requests per matching transaction. Cost therefore scales with *how many
+  * addresses are watched*, not with how busy the chain is, which is the whole reason this polls per
+  * address rather than fetching blocks.
+  *
+  * ## Reorgs: detected, not reconciled
+  *
+  * When `/blocks/{hash}/next` 404s, the block we last reported is no longer on chain. This follower
+  * does not walk back to the fork point — that is the rollback ring, and it is deliberately not in
+  * the light driver. It fails instead, with [[ResyncRequiredException]], so subscribers learn their
+  * view is untrustworthy rather than silently diverging from the chain. The provider declares
+  * `rollbackHorizon = None`, which stays truthful: it never emits `RolledBack`.
+  *
+  * @param pollInterval
+  *   how long to wait between polls. The main quota dial: every poll is at least one request
+  *   whether or not the chain moved.
+  * @param delay
+  *   how to wait. Injected so tests can drive the loop without real time.
+  */
+private[stream] final class BlockfrostChainFollower(
+    api: BlockfrostChainApi,
+    pollInterval: FiniteDuration,
+    delay: FiniteDuration => Future[Unit]
+)(using ec: ExecutionContext)
+    extends ChainFollower {
+
+    private val mailbox = Mailbox.delta[ChainEvent]()
+
+    // Guarded by `this`: mutated from the poll loop and from `watch` on the caller's thread.
+    private var watched: Set[UtxoSource] = Set.empty
+    private var last: Option[BlockRef] = None
+    private var stopped = false
+
+    override def events: ScalusAsyncSource[ChainEvent] = mailbox
+
+    override def watch(sources: Set[UtxoSource]): Unit = synchronized { watched = sources }
+
+    override def close(): Unit = {
+        synchronized { stopped = true }
+        mailbox.close()
+    }
+
+    private def isStopped: Boolean = synchronized(stopped)
+
+    /** Start polling. The loop is a `Future` chain, not a thread, so it works on Scala.js too. */
+    def start(): Unit = {
+        api.latestBlock().onComplete {
+            case Success(tip) =>
+                synchronized { last = Some(tip) }
+                loop()
+            case Failure(t) => mailbox.fail(t)
+        }
+    }
+
+    private def loop(): Unit = if !isStopped then
+        delay(pollInterval).flatMap(_ => if isStopped then Future.unit else poll()).onComplete {
+            case Success(_) => loop()
+            case Failure(t) => mailbox.fail(t)
+        }
+
+    private def poll(): Future[Unit] = {
+        val from = synchronized(last)
+        from match
+            case None => Future.unit
+            case Some(ref) =>
+                api.blocksAfter(ref).flatMap {
+                    case None =>
+                        Future.failed(
+                          ResyncRequiredException(
+                            s"block ${ref.blockNo} is no longer on chain, so the chain forked below " +
+                                "the last reported block; this provider detects reorgs but does " +
+                                "not reconcile them, and the subscriber's view cannot be trusted"
+                          )
+                        )
+                    case Some(blocks) => sequentially(blocks)(emitBlock)
+                }
+    }
+
+    /** Blocks must be observed in order — the hub takes each applied block's height as the new tip
+      * — so these cannot be run concurrently even though each is independent.
+      */
+    private def sequentially[A](items: Seq[A])(f: A => Future[Unit]): Future[Unit] =
+        items.foldLeft(Future.unit)((acc, a) =>
+            acc.flatMap(_ => if isStopped then Future.unit else f(a))
+        )
+
+    private def emitBlock(block: BlockRef): Future[Unit] = {
+        val sources = synchronized(watched)
+        val addresses = sources.collect { case UtxoSource.FromAddress(a) => a }
+        val hashes = Future
+            .sequence(
+              addresses.toSeq.map(a => api.addressTransactionsIn(a, block.blockNo, block.blockNo))
+            )
+            // One transaction can touch several watched addresses; the hub must see it once.
+            .map(_.flatten.distinct)
+        hashes
+            .flatMap(hs => Future.sequence(hs.map(api.transaction)))
+            .map { observed =>
+                val applied = observed.map(o => AppliedTransaction(o.tx, o.created, o.spent))
+                mailbox.offer(
+                  ChainEvent.RollForward(
+                    AppliedBlock(
+                      point = block.point,
+                      blockNo = block.blockNo,
+                      txs = applied,
+                      block = None,
+                      // Every height is reported, matches or not, and always with the full set of
+                      // sources probed at it — both halves of AppliedBlock's contract.
+                      coverage = BlockCoverage.Sources(sources)
+                    )
+                  )
+                )
+                synchronized { last = Some(block) }
+            }
+    }
+}

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
@@ -46,13 +46,22 @@ private[stream] trait ChainFollower {
       * takes effect**.
       *
       * A metered follower polls per source, so it must be told what anyone is actually subscribed
-      * to; one that reads whole blocks ignores this and reports its current height.
+      * to. One that reads whole blocks ignores `sources` and returns `0`: every block it produces
+      * has `BlockCoverage.Complete`, so "everything above 0 covers you" is simply true, and
+      * reporting its current height instead would understate what it covers and push the caller to
+      * lean on a snapshot it does not need.
       *
       * The return value is what makes a subscription's start point exact rather than approximate.
       * Registering a subscription and telling the follower to watch its sources are two steps, and
       * a block processed between them is covered by neither: the subscriber would be registered
       * from the tip, silently miss that block — nobody having fetched it on its behalf — and the
       * hub would then advance it past that height when the next covered block arrived.
+      *
+      * **The argument is the complete set, and calls must be serialised.** `sources` replaces what
+      * was being watched rather than adding to it, so a caller passes the union of every live
+      * subscription's sources every time. Two concurrent callers each passing only their own would
+      * leave one of them silently unwatched while holding a position that promises otherwise —
+      * which is the very failure this return value exists to prevent, reintroduced one layer up.
       *
       * So a follower returns the last height whose source set was already fixed. Every block above
       * it is guaranteed to have been assembled with `sources` included, which lets the caller

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
@@ -1,0 +1,54 @@
+package scalus.cardano.node.stream.internal
+
+import scalus.cardano.node.stream.{ChainTip, ScalusAsyncSource}
+
+/** One thing that happened to the chain, as a backend reports it.
+  *
+  * Deliberately normalised rather than backend-shaped. If a follower emitted its own wire types the
+  * driver below would need a branch per backend and the sharing would evaporate — the whole point
+  * is that everything downstream of this type is written once. Backend-shaped payloads are still
+  * worth keeping where they earn their place: recorded at the HTTP/WebSocket boundary, as test
+  * fixtures.
+  */
+private[stream] enum ChainEvent {
+
+    /** The chain advanced. See [[AppliedBlock]] for what a partial observation must state. */
+    case RollForward(block: AppliedBlock)
+
+    /** The chain switched to a different fork, and the follower can reconcile it. A follower that
+      * detects a reorg it *cannot* reconcile fails its source instead — see
+      * [[scalus.cardano.infra.ResyncRequiredException]].
+      */
+    case RollBackward(to: ChainTip)
+}
+
+/** Where a provider's chain events come from: the only thing a backend implements.
+  *
+  * Everything a subscription's correctness depends on — fan-out, confirmation gating, rollback
+  * delivery, watermarks — lives in [[SubscriptionHub]] and is shared. A backend supplies a sequence
+  * of [[ChainEvent]]s and nothing else, so Blockfrost polling, an Ogmios chain-sync stream and a
+  * UTxORPC feed differ only here.
+  *
+  * Sources are the seam for testing, too: a follower is a function from a fake backend to an event
+  * sequence, assertable without a hub, a subscription or a clock.
+  */
+private[stream] trait ChainFollower {
+
+    /** The follower's event stream. Single-consumer — [[HubDriver]] is the consumer.
+      *
+      * A failed pull ends the follower: the driver propagates the cause to every subscription
+      * rather than retrying, because a follower that cannot say what happened to the chain cannot
+      * let subscribers keep believing their view is current.
+      */
+    def events: ScalusAsyncSource[ChainEvent]
+
+    /** Which sources the follower should observe from now on.
+      *
+      * A metered follower polls per source, so it must be told what anyone is actually subscribed
+      * to; one that reads whole blocks ignores this. Called by the provider as subscriptions come
+      * and go, and the follower is expected to cope with it changing between polls.
+      */
+    def watch(sources: Set[scalus.cardano.node.UtxoSource]): Unit
+
+    def close(): Unit
+}

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
@@ -42,13 +42,24 @@ private[stream] trait ChainFollower {
       */
     def events: ScalusAsyncSource[ChainEvent]
 
-    /** Which sources the follower should observe from now on.
+    /** Which sources the follower should observe from now on, and **the height from which that
+      * takes effect**.
       *
       * A metered follower polls per source, so it must be told what anyone is actually subscribed
-      * to; one that reads whole blocks ignores this. Called by the provider as subscriptions come
-      * and go, and the follower is expected to cope with it changing between polls.
+      * to; one that reads whole blocks ignores this and reports its current height.
+      *
+      * The return value is what makes a subscription's start point exact rather than approximate.
+      * Registering a subscription and telling the follower to watch its sources are two steps, and
+      * a block processed between them is covered by neither: the subscriber would be registered
+      * from the tip, silently miss that block — nobody having fetched it on its behalf — and the
+      * hub would then advance it past that height when the next covered block arrived.
+      *
+      * So a follower returns the last height whose source set was already fixed. Every block above
+      * it is guaranteed to have been assembled with `sources` included, which lets the caller
+      * register the subscription at exactly that height instead of at whatever the tip happened to
+      * be. The guarantee becomes structural rather than a matter of how the two calls interleave.
       */
-    def watch(sources: Set[scalus.cardano.node.UtxoSource]): Unit
+    def watch(sources: Set[scalus.cardano.node.UtxoSource]): scalus.cardano.node.stream.BlockNo
 
     def close(): Unit
 }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/ChainFollower.scala
@@ -42,20 +42,14 @@ private[stream] trait ChainFollower {
       */
     def events: ScalusAsyncSource[ChainEvent]
 
-    /** Which sources the follower should observe from now on, and **the height from which that
-      * takes effect**.
+    /** Which sources the follower should observe from now on, and **the point from which that takes
+      * effect**.
       *
       * A metered follower polls per source, so it must be told what anyone is actually subscribed
-      * to. One that reads whole blocks ignores `sources` and returns `0`: every block it produces
-      * has `BlockCoverage.Complete`, so "everything above 0 covers you" is simply true, and
-      * reporting its current height instead would understate what it covers and push the caller to
-      * lean on a snapshot it does not need.
-      *
-      * The return value is what makes a subscription's start point exact rather than approximate.
-      * Registering a subscription and telling the follower to watch its sources are two steps, and
-      * a block processed between them is covered by neither: the subscriber would be registered
-      * from the tip, silently miss that block — nobody having fetched it on its behalf — and the
-      * hub would then advance it past that height when the next covered block arrived.
+      * to. One that reads whole blocks ignores `sources` and returns [[ChainPoint.origin]]: every
+      * block it produces has `BlockCoverage.Complete`, so "everything after the origin covers you"
+      * is simply true, and reporting its current position instead would understate what it covers
+      * and push the caller onto a snapshot it does not need.
       *
       * **The argument is the complete set, and calls must be serialised.** `sources` replaces what
       * was being watched rather than adding to it, so a caller passes the union of every live
@@ -63,12 +57,26 @@ private[stream] trait ChainFollower {
       * leave one of them silently unwatched while holding a position that promises otherwise —
       * which is the very failure this return value exists to prevent, reintroduced one layer up.
       *
-      * So a follower returns the last height whose source set was already fixed. Every block above
-      * it is guaranteed to have been assembled with `sources` included, which lets the caller
-      * register the subscription at exactly that height instead of at whatever the tip happened to
-      * be. The guarantee becomes structural rather than a matter of how the two calls interleave.
+      * The return value is what makes a subscription's start point exact rather than approximate.
+      * Registering a subscription and telling the follower to watch its sources are two steps, and
+      * a block processed between them is covered by neither: the subscriber would be registered
+      * from the tip, silently miss that block — nobody having fetched it on its behalf — and the
+      * hub would then advance it past that point when the next covered block arrived. So a follower
+      * returns the last position whose source set was already fixed; everything after it is
+      * guaranteed to have been assembled with `sources` included, and the caller closes the
+      * remaining gap with a snapshot taken afterwards.
+      *
+      * **A [[ChainPoint]], not a height.** Heights are only unique within a fork, and this seam is
+      * meant for followers that emit [[ChainEvent.RollBackward]]. After a reorg, "block 100" on the
+      * abandoned fork and on the new one are different blocks, and a caller told "everything above
+      * 100 covers you" would silently assign the replacement 100 to a snapshot describing the fork
+      * that no longer exists. A point names the block.
+      *
+      * A follower that rolls back therefore **must lower this to the rollback target** as it emits
+      * the `RollBackward`, since the blocks it replays afterwards are new blocks that no previous
+      * `watch` can have accounted for.
       */
-    def watch(sources: Set[scalus.cardano.node.UtxoSource]): scalus.cardano.node.stream.BlockNo
+    def watch(sources: Set[scalus.cardano.node.UtxoSource]): scalus.cardano.node.stream.ChainPoint
 
     def close(): Unit
 }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
@@ -1,6 +1,6 @@
 package scalus.cardano.node.stream.internal
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
 /** Pumps a [[ChainFollower]]'s events into a [[SubscriptionHub]].
@@ -18,9 +18,22 @@ private[stream] final class HubDriver(
 )(using ec: ExecutionContext) {
 
     @volatile private var stopped = false
+    @volatile private var started = false
 
-    /** Begin pumping. Idempotent in the sense that a stopped driver stays stopped. */
-    def start(): Unit = if !stopped then pump()
+    /** Begin pumping.
+      *
+      * Idempotent: a second call is ignored, and a stopped driver stays stopped. Two pumps would
+      * both pull from a source documented as single-consumer — `Mailbox.pull` hands concurrent
+      * callers the same promise — so a single event would be applied twice, appending the same
+      * block to `recent` and re-emitting its deltas.
+      */
+    def start(): Unit = {
+        val begin = synchronized {
+            if started || stopped then false
+            else { started = true; true }
+        }
+        if begin then pump()
+    }
 
     private def pump(): Unit =
         follower.events.pull().onComplete {
@@ -28,11 +41,19 @@ private[stream] final class HubDriver(
                 // Applying can throw — a rollback deeper than the horizon, a capability the
                 // provider declared it does not have. That is a failure of the whole feed, not of
                 // one event, so it travels the same path as a follower failure.
-                try
-                    apply(event)
-                    if !stopped then pump()
-                catch
-                    case t: Throwable => fail(t)
+                val continue =
+                    try
+                        apply(event)
+                        true
+                    catch
+                        case t: Throwable =>
+                            fail(t)
+                            false
+                // Re-dispatched rather than called here. A buffered backlog completes every pull
+                // synchronously, and under an inline executor a direct recursive call would nest
+                // one frame per drained event until the stack gave out — turning a queue that
+                // merely got long into a dead feed.
+                if continue && !stopped then Future.unit.foreach(_ => pump())
             // The follower ended cleanly: no more chain events are coming, so subscriptions are
             // complete rather than broken.
             case Success(None) => if !stopped then hub.closeAll()
@@ -47,13 +68,26 @@ private[stream] final class HubDriver(
       * it has no way to know is stale. Failing them all is the only honest option — the same
       * reasoning as a bounded buffer overflowing rather than dropping.
       */
-    private def fail(t: Throwable): Unit = if !stopped then {
-        stopped = true
-        hub.failAll(t)
+    private def fail(t: Throwable): Unit = {
+        val first = synchronized {
+            if stopped then false
+            else { stopped = true; true }
+        }
+        if first then hub.failAll(t)
     }
 
+    /** Stop pumping and end every subscription.
+      *
+      * Closing the hub here rather than relying on the follower's end-of-stream is deliberate: the
+      * pump is stopped by this call, so nothing is left to observe that end, and subscribers would
+      * be left parked on promises that never complete.
+      */
     def close(): Unit = {
-        stopped = true
+        val first = synchronized {
+            if stopped then false
+            else { stopped = true; true }
+        }
         follower.close()
+        if first then hub.closeAll()
     }
 }

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
@@ -1,0 +1,59 @@
+package scalus.cardano.node.stream.internal
+
+import scala.concurrent.ExecutionContext
+import scala.util.{Failure, Success}
+
+/** Pumps a [[ChainFollower]]'s events into a [[SubscriptionHub]].
+  *
+  * The half of a streaming provider that is the same whatever the backend is: pull an event, apply
+  * it, pull again. Written once so that Blockfrost, Ogmios and UTxORPC cannot each get the
+  * lifecycle subtly different.
+  *
+  * Not a thread. The loop is a `Future` continuation chain, so it runs wherever the follower
+  * completes its pulls and needs nothing that does not exist on Scala.js.
+  */
+private[stream] final class HubDriver(
+    hub: SubscriptionHub,
+    follower: ChainFollower
+)(using ec: ExecutionContext) {
+
+    @volatile private var stopped = false
+
+    /** Begin pumping. Idempotent in the sense that a stopped driver stays stopped. */
+    def start(): Unit = if !stopped then pump()
+
+    private def pump(): Unit =
+        follower.events.pull().onComplete {
+            case Success(Some(event)) =>
+                // Applying can throw — a rollback deeper than the horizon, a capability the
+                // provider declared it does not have. That is a failure of the whole feed, not of
+                // one event, so it travels the same path as a follower failure.
+                try
+                    apply(event)
+                    if !stopped then pump()
+                catch
+                    case t: Throwable => fail(t)
+            // The follower ended cleanly: no more chain events are coming, so subscriptions are
+            // complete rather than broken.
+            case Success(None) => if !stopped then hub.closeAll()
+            case Failure(t)    => fail(t)
+        }
+
+    private def apply(event: ChainEvent): Unit = event match
+        case ChainEvent.RollForward(block) => hub.applyBlock(block)
+        case ChainEvent.RollBackward(to)   => hub.rollbackTo(to)
+
+    /** A follower that cannot say what happened to the chain leaves every subscriber holding a view
+      * it has no way to know is stale. Failing them all is the only honest option — the same
+      * reasoning as a bounded buffer overflowing rather than dropping.
+      */
+    private def fail(t: Throwable): Unit = if !stopped then {
+        stopped = true
+        hub.failAll(t)
+    }
+
+    def close(): Unit = {
+        stopped = true
+        follower.close()
+    }
+}

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/HubDriver.scala
@@ -73,7 +73,12 @@ private[stream] final class HubDriver(
             if stopped then false
             else { stopped = true; true }
         }
-        if first then hub.failAll(t)
+        if first then {
+            // Stop the follower too. Nothing will read its events again, and a metered one left
+            // running keeps spending quota on a feed with no consumer.
+            follower.close()
+            hub.failAll(t)
+        }
     }
 
     /** Stop pumping and end every subscription.

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
@@ -366,6 +366,34 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
         touched.foreach(_.flush())
     }
 
+    /** Fail every subscription with `cause`, and stop accepting new ones.
+      *
+      * Distinct from [[closeAll]], and the distinction is the subscriber's whole world: a closed
+      * stream ended, so whatever it delivered was the truth; a failed stream means the view is
+      * untrustworthy and must be rebuilt. A follower that loses track of the chain owes subscribers
+      * the second, never the first.
+      */
+    def failAll(cause: Throwable): Unit = {
+        val mailboxes = synchronized {
+            closed = true
+            val all: Seq[Mailbox[?]] =
+                utxoSubs.values.toSeq.map(_.mailbox) ++
+                    txSubs.values.toSeq.map(_.mailbox) ++
+                    blockSubs.values.toSeq.map(_.mailbox) ++
+                    tipSubs.values.toSeq ++
+                    paramSubs.values.toSeq ++
+                    statusSubs.values.flatMap(_.values).toSeq
+            utxoSubs.clear()
+            txSubs.clear()
+            blockSubs.clear()
+            tipSubs.clear()
+            paramSubs.clear()
+            statusSubs.clear()
+            all
+        }
+        mailboxes.foreach(_.fail(cause))
+    }
+
     def closeAll(): Unit = {
         val mailboxes = synchronized {
             closed = true

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
@@ -2,7 +2,7 @@ package scalus.cardano.node.stream.internal
 
 import scalus.cardano.infra.{ResyncRequiredException, UnsupportedSubscriptionException}
 import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, TransactionHash}
-import scalus.cardano.node.TransactionStatus
+import scalus.cardano.node.{TransactionStatus, UtxoQuery, UtxoSource}
 import scalus.cardano.node.stream.*
 
 import scala.collection.mutable
@@ -288,7 +288,12 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
             // `+ 1` on a saturating max, so an absurd confirmation depth cannot wrap the window
             // negative and empty the deque on the next prune.
             val retain = math.max(securityParam, deepestGate).min(Int.MaxValue - 1) + 1
-            while recent.size > retain do recent.removeHead()
+            // Pruned by *height*, not by entry count: under partial coverage several blocks can
+            // share a height (one per set of sources probed there), and counting entries would
+            // then evict heights that are still inside the rollback horizon. With one entry per
+            // height — every Complete-coverage provider — this is the same window as before.
+            val oldest = block.blockNo - retain
+            while recent.nonEmpty && recent.head.blockNo <= oldest do recent.removeHead()
             val newTip = ChainTip(block.point, block.blockNo)
             tip = newTip
 
@@ -393,12 +398,19 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
             depthOf: S => Int,
             lastOf: S => BlockNo,
             advance: (S, BlockNo) => Unit,
-            emit: (S, AppliedBlock) => Seq[Mailbox[?]]
+            emit: (S, AppliedBlock) => Seq[Mailbox[?]],
+            covers: (S, AppliedBlock) => Boolean
         ): Seq[Mailbox[?]] = subs.toSeq.flatMap { sub =>
             val depth = depthOf(sub)
-            // Everything at or below the visible height that this subscription has not seen yet.
+            // Everything at or below the visible height that this subscription has not seen yet
+            // *and* that the provider actually examined on its behalf. Skipping the coverage test
+            // would not merely deliver an empty block: `emit` turns "no matches" into an `Idle`,
+            // and `advance` then moves the watermark past a height whose real events had not been
+            // looked for yet, so they could never be delivered afterwards.
             val visibleUpTo = tip.blockNo - depth
-            val due = recent.filter(b => b.blockNo > lastOf(sub) && b.blockNo <= visibleUpTo).toSeq
+            val due = recent
+                .filter(b => b.blockNo > lastOf(sub) && b.blockNo <= visibleUpTo && covers(sub, b))
+                .toSeq
             if due.isEmpty then Seq.empty
             else
                 advance(sub, due.last.blockNo)
@@ -410,21 +422,25 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
           s => effectiveDepth(s.opts),
           _.lastEmitted,
           (s, n) => s.lastEmitted = n,
-          (s, b) => { utxoEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) }
+          (s, b) => { utxoEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) },
+          (s, b) => coversUtxoQuery(s.query.query, b.coverage)
         )
         val txs = deliveries[TxSubscription](
           txSubs.values,
           s => effectiveDepth(s.opts),
           _.lastEmitted,
           (s, n) => s.lastEmitted = n,
-          (s, b) => { txEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) }
+          (s, b) => { txEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) },
+          (s, b) => coversTxQuery(s.query, b.coverage)
         )
         val blocks = deliveries[BlockSubscription](
           blockSubs.values,
           s => effectiveDepth(s.opts),
           _.lastEmitted,
           (s, n) => s.lastEmitted = n,
-          (s, b) => { blockEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) }
+          (s, b) => { blockEvents(s, b).foreach(s.mailbox.offerBuffered); Seq(s.mailbox) },
+          // A block subscription wants the block itself, which only a complete observation has.
+          (_, b) => b.coverage == BlockCoverage.Complete
         )
         utxo ++ txs ++ blocks
     }
@@ -452,6 +468,50 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
       */
     private def wantsIdle(opts: SubscriptionOptions): Boolean =
         capabilities.idleSignals && opts.idleSignals
+
+    /** Whether a block's coverage is authoritative for a UTxO subscription.
+      *
+      * A union needs every arm covered — the events we would otherwise miss are exactly the ones
+      * the uncovered arm would have found — which also means a query spanning two sources is
+      * covered only by a block that probed both. That is why a provider is expected to emit one
+      * block per height carrying the union of everything it probed there, rather than one block per
+      * watcher.
+      */
+    private def coversUtxoQuery(query: UtxoQuery, coverage: BlockCoverage): Boolean = query match
+        case q: UtxoQuery.Simple => BlockCoverage.covers(coverage, q.source)
+        case UtxoQuery.Or(l, r, _, _, _) =>
+            coversUtxoQuery(l, coverage) && coversUtxoQuery(r, coverage)
+
+    /** Whether a block's coverage is authoritative for a transaction subscription.
+      *
+      * Deliberately conservative: a leaf with no [[UtxoSource]] equivalent — `MintsPolicy` has no
+      * per-asset source to probe, `InvolvesScript` and `Not` have no index at all — is treated as
+      * uncovered unless the whole block was observed. Under-claiming coverage costs a subscription
+      * some latency; over-claiming it loses events silently.
+      */
+    private def coversTxQuery(query: TransactionQuery, coverage: BlockCoverage): Boolean =
+        coverage match
+            case BlockCoverage.Complete => true
+            case BlockCoverage.Sources(probed) =>
+                def covered(q: TransactionQuery): Boolean = q match
+                    case TransactionQuery.InvolvesAddress(a) =>
+                        probed.contains(UtxoSource.FromAddress(a))
+                    case TransactionQuery.MintsAsset(p, n) =>
+                        probed.contains(UtxoSource.FromAsset(p, n))
+                    case TransactionQuery.SpendsInput(i) =>
+                        probed.exists {
+                            case UtxoSource.FromInputs(inputs) => inputs.contains(i)
+                            case _                             => false
+                        }
+                    // An intersection can be answered from any one covered arm, with the rest
+                    // post-filtering data the block already contains.
+                    case TransactionQuery.AllOf(qs) => qs.exists(covered)
+                    // A union is only as covered as its worst arm.
+                    case TransactionQuery.AnyOf(qs) => qs.nonEmpty && qs.forall(covered)
+                    case TransactionQuery.All | _: TransactionQuery.MintsPolicy |
+                        _: TransactionQuery.InvolvesScript | _: TransactionQuery.Not =>
+                        false
+                covered(query)
 
     private def utxoEvents(sub: UtxoSubscription, block: AppliedBlock): Seq[UtxoEvent] = {
         val wantCreated = sub.query.types.contains(UtxoEventType.Created)

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
@@ -294,6 +294,12 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
             // height — every Complete-coverage provider — this is the same window as before.
             val oldest = block.blockNo - retain
             while recent.nonEmpty && recent.head.blockNo <= oldest do recent.removeHead()
+            // Belt and braces. The height window is the meaningful bound, but it bounds nothing if
+            // a provider breaks the one-block-per-ascending-height contract `AppliedBlock`
+            // documents — several entries per height, or a height that goes backwards, would let
+            // `recent` grow without limit and make `releaseLocked` scan it for every subscription
+            // on every block. A cap costs one comparison and removes the failure mode.
+            while recent.size > retain do recent.removeHead()
             val newTip = ChainTip(block.point, block.blockNo)
             tip = newTip
 
@@ -373,7 +379,14 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
       * untrustworthy and must be rebuilt. A follower that loses track of the chain owes subscribers
       * the second, never the first.
       */
-    def failAll(cause: Throwable): Unit = {
+    def failAll(cause: Throwable): Unit = terminateAll(_.fail(cause))
+
+    def closeAll(): Unit = terminateAll(_.close())
+
+    /** Shared by both terminations so that a future subscription kind cannot be remembered on one
+      * path and forgotten on the other — which would leak it silently on whichever was missed.
+      */
+    private def terminateAll(finish: Mailbox[?] => Unit): Unit = {
         val mailboxes = synchronized {
             closed = true
             val all: Seq[Mailbox[?]] =
@@ -391,35 +404,9 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
             statusSubs.clear()
             all
         }
-        mailboxes.foreach(_.fail(cause))
+        mailboxes.foreach(finish)
     }
 
-    def closeAll(): Unit = {
-        val mailboxes = synchronized {
-            closed = true
-            val all: Seq[Mailbox[?]] =
-                utxoSubs.values.toSeq.map(_.mailbox) ++
-                    txSubs.values.toSeq.map(_.mailbox) ++
-                    blockSubs.values.toSeq.map(_.mailbox) ++
-                    tipSubs.values.toSeq ++
-                    paramSubs.values.toSeq ++
-                    statusSubs.values.flatMap(_.values).toSeq
-            utxoSubs.clear()
-            txSubs.clear()
-            blockSubs.clear()
-            tipSubs.clear()
-            paramSubs.clear()
-            statusSubs.clear()
-            all
-        }
-        mailboxes.foreach(_.close())
-    }
-
-    // ------------------------------------------------------------------
-    // Internals — all called under the monitor
-    // ------------------------------------------------------------------
-
-    /** Release, per subscription, every block that has now reached its confirmation depth. */
     private def releaseLocked(): Seq[Mailbox[?]] = {
         def deliveries[S](
             subs: Iterable[S],
@@ -505,10 +492,13 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
       * block per height carrying the union of everything it probed there, rather than one block per
       * watcher.
       */
-    private def coversUtxoQuery(query: UtxoQuery, coverage: BlockCoverage): Boolean = query match
-        case q: UtxoQuery.Simple => BlockCoverage.covers(coverage, q.source)
-        case UtxoQuery.Or(l, r, _, _, _) =>
-            coversUtxoQuery(l, coverage) && coversUtxoQuery(r, coverage)
+    private def coversUtxoQuery(query: UtxoQuery, coverage: BlockCoverage): Boolean =
+        // Settled by one comparison for every complete-coverage provider — which is every provider
+        // but the metered one — instead of walking the query tree per subscription per block.
+        coverage == BlockCoverage.Complete || (query match
+            case q: UtxoQuery.Simple => BlockCoverage.covers(coverage, q.source)
+            case UtxoQuery.Or(l, r, _, _, _) =>
+                coversUtxoQuery(l, coverage) && coversUtxoQuery(r, coverage))
 
     /** Whether a block's coverage is authoritative for a transaction subscription.
       *

--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/stream/internal/SubscriptionHub.scala
@@ -1,7 +1,7 @@
 package scalus.cardano.node.stream.internal
 
 import scalus.cardano.infra.{ResyncRequiredException, UnsupportedSubscriptionException}
-import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, TransactionHash}
+import scalus.cardano.ledger.{CardanoInfo, ProtocolParams, TransactionHash, Utxos}
 import scalus.cardano.node.{TransactionStatus, UtxoQuery, UtxoSource}
 import scalus.cardano.node.stream.*
 
@@ -159,7 +159,7 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
             val wantsCreated = query.types.contains(UtxoEventType.Created)
             if opts.includeExistingUtxos && wantsCreated then
                 QueryMatching
-                    .matching(query.query, seed)
+                    .matching(query.query, rewindSeed(seed, sub.lastEmitted))
                     .foreach(u =>
                         mailbox.offerBuffered(
                           UtxoEvent.Created(u, u.input.transactionId, ChainPoint.origin)
@@ -474,6 +474,32 @@ final class SubscriptionHub(val cardanoInfo: CardanoInfo, val capabilities: Stre
       * that range offer it a `RolledBack` retracting events it never received — which is exactly
       * the guarantee `noRollback` sells.
       */
+    /** The seed as it stood at `from`, rather than at the tip.
+      *
+      * A snapshot describes the chain *now*, but a subscription's watermark starts at
+      * `tip - depth`, so the blocks in between are still to be delivered. Seeding from the current
+      * snapshot therefore double-reports them: a UTxO created in one of those blocks arrives once
+      * in the seed and again when the block is released. Worse in the other direction, a UTxO
+      * created before the window and spent inside it is missing from the snapshot, so the
+      * subscriber is handed a `Spent` for something it never saw created.
+      *
+      * The hub is holding those blocks already, and `AppliedTransaction.spent` carries the
+      * *resolved* outputs, so the snapshot can simply be wound back over them: drop what they
+      * created, restore what they consumed. A UTxO both created and spent inside the window belongs
+      * to neither — it did not exist at `from` — which is why `created` is subtracted from the
+      * restored set too.
+      *
+      * At the default depth of zero there are no pending blocks and this is the snapshot unchanged.
+      */
+    private def rewindSeed(snapshot: scalus.cardano.ledger.Utxos, from: BlockNo): Utxos = {
+        val pending = recent.filter(_.blockNo > from).toSeq.flatMap(_.txs)
+        if pending.isEmpty then snapshot
+        else
+            val createdSince = pending.flatMap(_.created.keys).toSet
+            val spentSince = pending.flatMap(_.spent).toMap
+            (snapshot -- createdSince) ++ (spentSince -- createdSince)
+    }
+
     private def watermark(opts: SubscriptionOptions): BlockNo =
         math.max(0L, tip.blockNo - effectiveDepth(opts))
 

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockCoverageTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockCoverageTest.scala
@@ -1,0 +1,157 @@
+package scalus.cardano.node.stream
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.Address
+import scalus.cardano.ledger.*
+import scalus.cardano.node.stream.internal.{AppliedBlock, BlockCoverage, Mailbox, SubscriptionHub}
+import scalus.cardano.node.{UtxoQuery, UtxoSource}
+import scalus.testing.kit.Party
+import scalus.uplc.builtin.ByteString
+
+/** Delivery under partial coverage.
+  *
+  * A metered provider cannot afford to fetch whole blocks, so what it learns about a height is only
+  * ever "what these sources did in it". The hub delivers a block and advances the receiving
+  * subscription's watermark in one step, so a block that did not cover a subscription must not
+  * reach it — otherwise it is told "nothing here for you" about a height nobody looked at on its
+  * behalf, and the real events for that height become undeliverable.
+  */
+class BlockCoverageTest extends AnyFunSuite {
+
+    private given CardanoInfo = CardanoInfo.mainnet
+
+    private val alice = Party.Alice.address
+    private val bob = Party.Bob.address
+
+    private val caps = StreamCapabilities(
+      kinds = SubscriptionKind.all,
+      pushdown = PushdownKind.all,
+      // Metered is the whole reason partial coverage exists.
+      scanning = ScanCost.Metered,
+      replay = ReplaySupport.NoReplay,
+      rollbackHorizon = None,
+      maxConfirmations = None,
+      idleSignals = true
+    )
+
+    private def hub() = new SubscriptionHub(CardanoInfo.mainnet, caps)
+
+    private def point(n: Long): ChainPoint = {
+        val bytes = new Array[Byte](32)
+        bytes(31) = n.toByte
+        ChainPoint(n, BlockHash.fromByteString(ByteString.fromArray(bytes)))
+    }
+
+    private def probing(n: Long, addresses: Address*): AppliedBlock = AppliedBlock(
+      point(n),
+      n,
+      Seq.empty,
+      None,
+      BlockCoverage.Sources(addresses.map(UtxoSource.FromAddress(_)).toSet)
+    )
+
+    private def complete(n: Long): AppliedBlock = AppliedBlock(point(n), n, Seq.empty)
+
+    private def watch(h: SubscriptionHub, address: Address): Mailbox[UtxoEvent] = {
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        h.registerUtxo(
+          h.nextSubscriptionId(),
+          UtxoEventQuery(UtxoQuery(UtxoSource.FromAddress(address)), UtxoEventType.all),
+          // idleSignals is off by default; these tests are about which blocks produce a progress
+          // signal, so without it every assertion below would hold vacuously.
+          SubscriptionOptions(
+            includeExistingUtxos = false,
+            idleSignals = true,
+            allowUnindexedScan = true
+          ),
+          mailbox,
+          Map.empty
+        )
+        mailbox
+    }
+
+    private def drain[A](m: Mailbox[A]): List[A] = {
+        val buf = List.newBuilder[A]
+        var more = true
+        while more do
+            m.pull().value.flatMap(_.toOption).flatten match
+                case Some(a) => buf += a
+                case None    => more = false
+        buf.result()
+    }
+
+    private def idlePoints(m: Mailbox[UtxoEvent]): List[ChainPoint] =
+        drain(m).collect { case UtxoEvent.Idle(at) => at }
+
+    test("a block that probed another source does not idle an uncovered subscription") {
+        val h = hub()
+        val watchingBob = watch(h, bob)
+
+        h.applyBlock(probing(1L, alice))
+
+        assert(
+          idlePoints(watchingBob).isEmpty,
+          "Idle claims the provider looked and found nothing; it looked for Alice, not for Bob, " +
+              "and saying otherwise reports progress that was never made"
+        )
+    }
+
+    test("a covered subscription still gets its idle signal") {
+        val h = hub()
+        val watchingAlice = watch(h, alice)
+
+        h.applyBlock(probing(1L, alice))
+
+        assert(
+          idlePoints(watchingAlice) == List(point(1L)),
+          "coverage gates delivery; it must not suppress it for the source actually probed"
+        )
+    }
+
+    test("a subscription is not advanced over heights examined only for others") {
+        val h = hub()
+        val watchingBob = watch(h, bob)
+
+        // A provider on a request budget probes Alice at height 1 and gets to both at height 2.
+        h.applyBlock(probing(1L, alice))
+        h.applyBlock(probing(2L, alice, bob))
+
+        assert(
+          idlePoints(watchingBob) == List(point(2L)),
+          "height 1 was never examined for Bob, so it is neither an event nor progress for him"
+        )
+    }
+
+    test("complete coverage reaches every subscription, as it always did") {
+        val h = hub()
+        val watchingAlice = watch(h, alice)
+        val watchingBob = watch(h, bob)
+
+        h.applyBlock(complete(1L))
+
+        assert(idlePoints(watchingAlice) == List(point(1L)))
+        assert(idlePoints(watchingBob) == List(point(1L)))
+    }
+
+    test("a union is only as covered as its worst arm") {
+        val probed = BlockCoverage.Sources(
+          Set(UtxoSource.FromAddress(alice))
+        )
+        val union = UtxoSource.Or(UtxoSource.FromAddress(alice), UtxoSource.FromAddress(bob))
+        assert(
+          !BlockCoverage.covers(probed, union),
+          "the events we would miss are exactly the ones the unprobed arm would have found"
+        )
+        assert(BlockCoverage.covers(probed, UtxoSource.FromAddress(alice)))
+    }
+
+    test("an intersection needs only one covered arm, since the rest post-filters") {
+        val probed = BlockCoverage.Sources(Set(UtxoSource.FromAddress(alice)))
+        val both =
+            UtxoSource.And(UtxoSource.FromAddress(alice), UtxoSource.FromAddress(bob))
+        assert(
+          BlockCoverage.covers(probed, both),
+          "probing Alice yields every candidate; the other condition filters data already in hand"
+        )
+    }
+}

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockCoverageTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockCoverageTest.scala
@@ -27,7 +27,7 @@ class BlockCoverageTest extends AnyFunSuite {
       kinds = SubscriptionKind.all,
       pushdown = PushdownKind.all,
       // Metered is the whole reason partial coverage exists.
-      scanning = ScanCost.Metered,
+      scanning = ScanSupport.Metered,
       replay = ReplaySupport.NoReplay,
       rollbackHorizon = None,
       maxConfirmations = None,

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
@@ -158,4 +158,47 @@ class BlockfrostChainFollowerTest extends AnyFunSuite {
           "no subscriptions means no per-address cost, but the tip must still advance"
         )
     }
+    test("watch reports the height its source set takes effect from") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
+        val f = follower(api, polls = 1)
+        f.start()
+
+        // The follower has processed up to 12, so a set installed now governs 13 onwards.
+        assert(
+          f.watch(Set(UtxoSource.FromAddress(alice))) == 12L,
+          "a subscription registered against this position is covered by every block above it, " +
+              "which is what makes its start point exact rather than whatever the tip happened " +
+              "to be when the two calls interleaved"
+        )
+    }
+
+    test("watch before any block reports the position nothing was observed from") {
+        val api = new FakeApi(ref(10L))
+        val f = follower(api, polls = 0)
+
+        assert(
+          f.watch(Set(UtxoSource.FromAddress(alice))) == 0L,
+          "nothing has been observed yet, so a subscription registered here must not be treated " +
+              "as having already been delivered anything"
+        )
+    }
+
+    test("a block already being assembled is not claimed by a later watch") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L)))
+        val f = follower(api, polls = 1)
+        f.start()
+
+        // Block 11 fixed its source set (empty) before this call, so watch must not report a
+        // position that would imply 11 was covered by the new set.
+        val from = f.watch(Set(UtxoSource.FromAddress(alice)))
+        val emitted = drain(f.events).collect { case ChainEvent.RollForward(b) => b }
+
+        assert(emitted.map(_.blockNo) == List(11L))
+        assert(
+          emitted.head.coverage == BlockCoverage.Sources(Set.empty),
+          "block 11 was assembled before the watch, and says so"
+        )
+        assert(from >= 11L, "so a subscription starting here must start above block 11, not at it")
+    }
+
 }

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
@@ -158,6 +158,7 @@ class BlockfrostChainFollowerTest extends AnyFunSuite {
           "no subscriptions means no per-address cost, but the tip must still advance"
         )
     }
+
     test("watch reports the height its source set takes effect from") {
         val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
         val f = follower(api, polls = 1)

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
@@ -10,7 +10,7 @@ import scalus.testing.kit.Party
 import scalus.uplc.builtin.ByteString
 
 import scala.concurrent.duration.*
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future, Promise}
 
 /** The polling loop, driven against a fake Blockfrost.
   *
@@ -24,6 +24,7 @@ class BlockfrostChainFollowerTest extends AnyFunSuite {
     private given ExecutionContext = ExecutionContext.parasitic
 
     private val alice = Party.Alice.address
+    private val bob = Party.Bob.address
 
     private def point(n: Long): ChainPoint = {
         val bytes = new Array[Byte](32)
@@ -65,6 +66,33 @@ class BlockfrostChainFollowerTest extends AnyFunSuite {
             txQueries = hash :: txQueries
             Future.failed(new AssertionError("no transactions in these fixtures"))
         }
+    }
+
+    /** A Blockfrost whose address query can be held open, so a `watch` can land while a block is
+      * part-way through being assembled.
+      */
+    private class GatedApi(tip: BlockRef, chain: Seq[BlockRef]) extends BlockfrostChainApi {
+        private val gate = Promise[Seq[TransactionHash]]()
+        @volatile var parked = false
+
+        override def latestBlock(): Future[BlockRef] = Future.successful(tip)
+
+        override def blocksAfter(block: BlockRef): Future[Option[Seq[BlockRef]]] =
+            Future.successful(Some(chain.filter(_.blockNo > block.blockNo)))
+
+        override def addressTransactionsIn(
+            address: Address,
+            from: BlockNo,
+            to: BlockNo
+        ): Future[Seq[TransactionHash]] = {
+            parked = true
+            gate.future
+        }
+
+        override def transaction(hash: TransactionHash): Future[ObservedTransaction] =
+            Future.failed(new AssertionError("no transactions in these fixtures"))
+
+        def release(): Unit = gate.success(Seq.empty)
     }
 
     /** Runs the loop synchronously: every future is already completed, so `delay` returning a
@@ -159,47 +187,54 @@ class BlockfrostChainFollowerTest extends AnyFunSuite {
         )
     }
 
-    test("watch reports the height its source set takes effect from") {
-        val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
-        val f = follower(api, polls = 1)
-        f.start()
-
-        // The follower has processed up to 12, so a set installed now governs 13 onwards.
-        assert(
-          f.watch(Set(UtxoSource.FromAddress(alice))) == 12L,
-          "a subscription registered against this position is covered by every block above it, " +
-              "which is what makes its start point exact rather than whatever the tip happened " +
-              "to be when the two calls interleaved"
-        )
-    }
-
-    test("watch before any block reports the position nothing was observed from") {
+    test("watch before anything is observed reports the origin") {
         val api = new FakeApi(ref(10L))
         val f = follower(api, polls = 0)
 
         assert(
-          f.watch(Set(UtxoSource.FromAddress(alice))) == 0L,
-          "nothing has been observed yet, so a subscription registered here must not be treated " +
-              "as having already been delivered anything"
+          f.watch(Set(UtxoSource.FromAddress(alice))) == ChainPoint.origin,
+          "nothing has been observed yet, so there is no block a subscription must start after"
         )
     }
 
-    test("a block already being assembled is not claimed by a later watch") {
-        val api = new FakeApi(ref(10L), chain = Seq(ref(11L)))
+    test("watch reports the position its source set takes effect from") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
         val f = follower(api, polls = 1)
         f.start()
 
-        // Block 11 fixed its source set (empty) before this call, so watch must not report a
-        // position that would imply 11 was covered by the new set.
-        val from = f.watch(Set(UtxoSource.FromAddress(alice)))
-        val emitted = drain(f.events).collect { case ChainEvent.RollForward(b) => b }
-
-        assert(emitted.map(_.blockNo) == List(11L))
         assert(
-          emitted.head.coverage == BlockCoverage.Sources(Set.empty),
-          "block 11 was assembled before the watch, and says so"
+          f.watch(Set(UtxoSource.FromAddress(alice))) == point(12L),
+          "12 was the last block whose sources were decided, so a subscription registered now is " +
+              "covered from 13 onwards and the caller's snapshot must cover the rest"
         )
-        assert(from >= 11L, "so a subscription starting here must start above block 11, not at it")
     }
 
+    test("a block still being assembled is not claimed by a watch that lands during it") {
+        // The real interleaving: the follower parks mid-block, holding the source set it already
+        // read, and a watch arrives while it is parked. Assembled-inline fixtures cannot reach
+        // this, and it is the only case that distinguishes recording the source set *before* the
+        // block's requests from recording it after.
+        val api = new GatedApi(ref(10L), chain = Seq(ref(11L)))
+        val f = follower(api, polls = 1)
+        f.watch(Set(UtxoSource.FromAddress(alice)))
+        f.start()
+
+        assert(api.parked, "block 11 should be mid-assembly, waiting on its address query")
+
+        val from = f.watch(Set(UtxoSource.FromAddress(alice), UtxoSource.FromAddress(bob)))
+        assert(
+          from == point(11L),
+          "block 11 fixed its sources before this watch, so the caller must be told to start " +
+              "after 11 — reporting 10 would claim 11 covers bob when it was assembled without him"
+        )
+
+        api.release()
+        val emitted = drain(f.events).collect { case ChainEvent.RollForward(b) => b }
+        assert(
+          emitted.map(_.coverage) == List(
+            BlockCoverage.Sources(Set(UtxoSource.FromAddress(alice)))
+          ),
+          "and the block itself reports only what it actually probed"
+        )
+    }
 }

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/BlockfrostChainFollowerTest.scala
@@ -1,0 +1,161 @@
+package scalus.cardano.node.stream
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.Address
+import scalus.cardano.infra.ResyncRequiredException
+import scalus.cardano.ledger.*
+import scalus.cardano.node.UtxoSource
+import scalus.cardano.node.stream.internal.*
+import scalus.testing.kit.Party
+import scalus.uplc.builtin.ByteString
+
+import scala.concurrent.duration.*
+import scala.concurrent.{ExecutionContext, Future}
+
+/** The polling loop, driven against a fake Blockfrost.
+  *
+  * This is what the follower seam is for: the behaviour worth pinning here — how many requests a
+  * poll costs, that every height is reported whether or not it matched, and what happens when the
+  * chain forks under us — is all reachable without HTTP, a key or real time.
+  */
+class BlockfrostChainFollowerTest extends AnyFunSuite {
+
+    private given CardanoInfo = CardanoInfo.mainnet
+    private given ExecutionContext = ExecutionContext.parasitic
+
+    private val alice = Party.Alice.address
+
+    private def point(n: Long): ChainPoint = {
+        val bytes = new Array[Byte](32)
+        bytes(31) = n.toByte
+        ChainPoint(n, BlockHash.fromByteString(ByteString.fromArray(bytes)))
+    }
+
+    private def ref(n: Long): BlockRef = BlockRef(point(n), n)
+
+    /** A scripted Blockfrost. `chain` is what `/blocks/{hash}/next` will hand back; `forked` makes
+      * it answer 404, which is how a reorg reaches the follower.
+      */
+    private class FakeApi(
+        tip: BlockRef,
+        var chain: Seq[BlockRef] = Seq.empty,
+        var forked: Boolean = false
+    ) extends BlockfrostChainApi {
+        var addressQueries: List[(Address, BlockNo)] = Nil
+        var txQueries: List[TransactionHash] = Nil
+
+        override def latestBlock(): Future[BlockRef] = Future.successful(tip)
+
+        override def blocksAfter(block: BlockRef): Future[Option[Seq[BlockRef]]] =
+            if forked then Future.successful(None)
+            else
+                val next = chain.filter(_.blockNo > block.blockNo)
+                Future.successful(Some(next))
+
+        override def addressTransactionsIn(
+            address: Address,
+            from: BlockNo,
+            to: BlockNo
+        ): Future[Seq[TransactionHash]] = {
+            addressQueries = (address, from) :: addressQueries
+            Future.successful(Seq.empty)
+        }
+
+        override def transaction(hash: TransactionHash): Future[ObservedTransaction] = {
+            txQueries = hash :: txQueries
+            Future.failed(new AssertionError("no transactions in these fixtures"))
+        }
+    }
+
+    /** Runs the loop synchronously: every future is already completed, so `delay` returning a
+      * completed unit makes the whole poll cycle run inline on `start()`.
+      */
+    private def follower(api: BlockfrostChainApi, polls: Int): BlockfrostChainFollower = {
+        var remaining = polls
+        val f = new BlockfrostChainFollower(
+          api,
+          1.second,
+          _ =>
+              if remaining <= 0 then Future.never
+              else
+                  remaining -= 1
+                  Future.unit
+        )
+        f
+    }
+
+    private def drain(source: ScalusAsyncSource[ChainEvent]): List[ChainEvent] = {
+        val buf = List.newBuilder[ChainEvent]
+        var more = true
+        while more do
+            source.pull().value.flatMap(_.toOption).flatten match
+                case Some(e) => buf += e
+                case None    => more = false
+        buf.result()
+    }
+
+    test("a poll that finds no new block reports nothing") {
+        val api = new FakeApi(ref(10L))
+        val f = follower(api, polls = 1)
+        f.start()
+        assert(drain(f.events).isEmpty, "no block, no event — Idle is the hub's business, not ours")
+        assert(api.addressQueries.isEmpty, "an unchanged tip must not cost a per-address request")
+    }
+
+    test("every new height is reported, matched or not") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
+        val f = follower(api, polls = 1)
+        f.watch(Set(UtxoSource.FromAddress(alice)))
+        f.start()
+
+        val forwarded = drain(f.events).collect { case ChainEvent.RollForward(b) => b }
+        assert(
+          forwarded.map(_.blockNo) == List(11L, 12L),
+          "a height with no matches still has to be reported, or subscriptions never advance"
+        )
+        assert(
+          forwarded.forall(_.coverage == BlockCoverage.Sources(Set(UtxoSource.FromAddress(alice)))),
+          "coverage names every source probed at that height"
+        )
+    }
+
+    test("cost is one address request per watched address per block") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L), ref(12L)))
+        val f = follower(api, polls = 1)
+        f.watch(Set(UtxoSource.FromAddress(alice)))
+        f.start()
+
+        assert(
+          api.addressQueries.map(_._2).sorted == List(11L, 12L),
+          "one query per address per block, scoped to that block — not a scan of the address's " +
+              "whole history, which is what makes this affordable"
+        )
+    }
+
+    test("a fork under the last reported block fails the stream, and says to resync") {
+        val api = new FakeApi(ref(10L), forked = true)
+        val f = follower(api, polls = 1)
+        f.start()
+
+        val failure = f.events.pull().value.get
+        assert(failure.isFailure)
+        assert(
+          failure.failed.get.isInstanceOf[ResyncRequiredException],
+          "the light driver detects reorgs but does not reconcile them; a subscriber must be told " +
+              "its view is untrustworthy rather than left to diverge silently"
+        )
+    }
+
+    test("watching nothing still tracks the chain") {
+        val api = new FakeApi(ref(10L), chain = Seq(ref(11L)))
+        val f = follower(api, polls = 1)
+        f.start()
+
+        val forwarded = drain(f.events).collect { case ChainEvent.RollForward(b) => b }
+        assert(forwarded.map(_.blockNo) == List(11L))
+        assert(
+          api.addressQueries.isEmpty,
+          "no subscriptions means no per-address cost, but the tip must still advance"
+        )
+    }
+}

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
@@ -41,7 +41,7 @@ class HubDriverTest extends AnyFunSuite {
         val mailbox: Mailbox[ChainEvent] = Mailbox.delta[ChainEvent]()
         var closed = false
         override def events: ScalusAsyncSource[ChainEvent] = mailbox
-        override def watch(sources: Set[UtxoSource]): Unit = ()
+        override def watch(sources: Set[UtxoSource]): BlockNo = 0L
         override def close(): Unit = { closed = true; mailbox.close() }
     }
 

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
@@ -23,7 +23,7 @@ class HubDriverTest extends AnyFunSuite {
     private val caps = StreamCapabilities(
       kinds = SubscriptionKind.all,
       pushdown = PushdownKind.all,
-      scanning = ScanCost.Free,
+      scanning = ScanSupport.Free,
       replay = ReplaySupport.NoReplay,
       rollbackHorizon = None,
       maxConfirmations = None,

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
@@ -1,0 +1,144 @@
+package scalus.cardano.node.stream
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.ledger.*
+import scalus.cardano.node.stream.internal.*
+import scalus.cardano.node.{UtxoQuery, UtxoSource}
+import scalus.testing.kit.Party
+import scalus.uplc.builtin.ByteString
+
+import scala.concurrent.ExecutionContext
+
+/** The component that joins a follower to the hub, and therefore owns the lifecycle: what a clean
+  * end of stream means, what a failure means, and what closing means. All three are observable only
+  * as "what happens to a subscriber who is waiting", which is what these assert.
+  */
+class HubDriverTest extends AnyFunSuite {
+
+    private given CardanoInfo = CardanoInfo.mainnet
+    private given ExecutionContext = ExecutionContext.parasitic
+
+    private val alice = Party.Alice.address
+
+    private val caps = StreamCapabilities(
+      kinds = SubscriptionKind.all,
+      pushdown = PushdownKind.all,
+      scanning = ScanCost.Free,
+      replay = ReplaySupport.NoReplay,
+      rollbackHorizon = None,
+      maxConfirmations = None,
+      idleSignals = true
+    )
+
+    private def point(n: Long): ChainPoint = {
+        val bytes = new Array[Byte](32)
+        bytes(31) = n.toByte
+        ChainPoint(n, BlockHash.fromByteString(ByteString.fromArray(bytes)))
+    }
+
+    /** A follower whose events are pushed by the test rather than polled from anywhere. */
+    private class ManualFollower extends ChainFollower {
+        val mailbox: Mailbox[ChainEvent] = Mailbox.delta[ChainEvent]()
+        var closed = false
+        override def events: ScalusAsyncSource[ChainEvent] = mailbox
+        override def watch(sources: Set[UtxoSource]): Unit = ()
+        override def close(): Unit = { closed = true; mailbox.close() }
+    }
+
+    private def subscribe(hub: SubscriptionHub): Mailbox[UtxoEvent] = {
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        hub.registerUtxo(
+          hub.nextSubscriptionId(),
+          UtxoEventQuery(UtxoQuery(UtxoSource.FromAddress(alice)), UtxoEventType.all),
+          SubscriptionOptions(includeExistingUtxos = false),
+          mailbox,
+          Map.empty
+        )
+        mailbox
+    }
+
+    private def fixture(): (SubscriptionHub, ManualFollower, HubDriver) = {
+        val hub = new SubscriptionHub(CardanoInfo.mainnet, caps)
+        val follower = new ManualFollower
+        val driver = new HubDriver(hub, follower)
+        (hub, follower, driver)
+    }
+
+    test("events reach the hub, and the tip advances") {
+        val (hub, follower, driver) = fixture()
+        driver.start()
+        follower.mailbox.offer(ChainEvent.RollForward(AppliedBlock(point(1L), 1L, Seq.empty)))
+        assert(hub.currentTip.blockNo == 1L)
+    }
+
+    test("a clean end of stream completes subscribers rather than parking them") {
+        val (hub, follower, driver) = fixture()
+        val sub = subscribe(hub)
+        driver.start()
+        follower.mailbox.close()
+
+        assert(
+          sub.pull().value.contains(scala.util.Success(None)),
+          "the chain feed ended, so subscriptions are finished — not broken, and not left waiting"
+        )
+    }
+
+    test("a failed feed fails subscribers, so nobody trusts a stale view") {
+        val (hub, follower, driver) = fixture()
+        val sub = subscribe(hub)
+        driver.start()
+        follower.mailbox.fail(new RuntimeException("backend fell over"))
+
+        val settled = sub.pull().value.get
+        assert(settled.isFailure, "a subscriber must learn its view stopped tracking the chain")
+    }
+
+    test("close() ends subscriptions instead of leaving them waiting forever") {
+        val (hub, follower, driver) = fixture()
+        val sub = subscribe(hub)
+        driver.start()
+        driver.close()
+
+        assert(follower.closed, "closing the driver closes its follower")
+        assert(
+          sub.pull().value.contains(scala.util.Success(None)),
+          "the driver is the only thing observing the follower's end, so if it stops pumping " +
+              "before that arrives it has to end the subscriptions itself"
+        )
+    }
+
+    test("a second start() is harmless") {
+        val (hub, follower, driver) = fixture()
+        driver.start()
+        driver.start()
+
+        follower.mailbox.offer(ChainEvent.RollForward(AppliedBlock(point(1L), 1L, Seq.empty)))
+        follower.mailbox.offer(ChainEvent.RollForward(AppliedBlock(point(2L), 2L, Seq.empty)))
+        assert(hub.currentTip.blockNo == 2L)
+    }
+    // Honest scope: this does not *detect* a missing `started` guard, and pretending otherwise
+    // would be worse than not having it. Without the guard both pumps are handed the same pull
+    // promise and apply the same event twice — but the second application is almost invisible from
+    // outside, because `releaseLocked` has already advanced the watermark past that height, so no
+    // duplicate events are emitted. What it actually corrupts is `recent`, which gains a second
+    // entry at one height and so breaks the one-block-per-ascending-height invariant that
+    // `AppliedBlock` documents and that pruning relies on. The guard is defensive; this test only
+    // pins that a double start does not break ordinary progress.
+
+    test("a large backlog drains completely") {
+        val (hub, follower, driver) = fixture()
+        // Buffered before the driver starts, so every pull completes synchronously — the shape
+        // that makes a recursive pump nest one frame per event.
+        (1L to 20000L).foreach(n =>
+            follower.mailbox.offer(ChainEvent.RollForward(AppliedBlock(point(n), n, Seq.empty)))
+        )
+        driver.start()
+
+        assert(hub.currentTip.blockNo == 20000L, "every buffered event must reach the hub")
+    }
+    // Also honest scope: 20,000 nested frames did *not* overflow when tried against the recursive
+    // version, so this is a drain-completeness test, not a stack-safety one. Stack safety is
+    // argued in `pump`'s comment and enforced by re-dispatching rather than recursing; a test that
+    // reliably demonstrated the overflow would have to be tuned to a particular stack size and
+    // would be flaky across JVMs and Scala.js.
+}

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/HubDriverTest.scala
@@ -41,7 +41,8 @@ class HubDriverTest extends AnyFunSuite {
         val mailbox: Mailbox[ChainEvent] = Mailbox.delta[ChainEvent]()
         var closed = false
         override def events: ScalusAsyncSource[ChainEvent] = mailbox
-        override def watch(sources: Set[UtxoSource]): BlockNo = 0L
+        // Complete coverage: everything after the origin covers any subscription.
+        override def watch(sources: Set[UtxoSource]): ChainPoint = ChainPoint.origin
         override def close(): Unit = { closed = true; mailbox.close() }
     }
 

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionHubTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionHubTest.scala
@@ -22,7 +22,7 @@ class SubscriptionHubTest extends AnyFunSuite {
     ): StreamCapabilities = StreamCapabilities(
       kinds = SubscriptionKind.all,
       pushdown = PushdownKind.all,
-      scanning = ScanCost.Free,
+      scanning = ScanSupport.Free,
       replay = ReplaySupport.NoReplay,
       rollbackHorizon = rollbackHorizon,
       maxConfirmations = None,

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionHubTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionHubTest.scala
@@ -2,7 +2,7 @@ package scalus.cardano.node.stream
 
 import org.scalatest.funsuite.AnyFunSuite
 import scalus.cardano.ledger.*
-import scalus.cardano.node.stream.internal.{AppliedBlock, Mailbox, SubscriptionHub}
+import scalus.cardano.node.stream.internal.{AppliedBlock, AppliedTransaction, Mailbox, SubscriptionHub}
 import scalus.cardano.node.{UtxoQuery, UtxoSource}
 import scalus.testing.kit.Party
 import scalus.uplc.builtin.ByteString
@@ -165,4 +165,115 @@ class SubscriptionHubTest extends AnyFunSuite {
         )
         assertThrows[scalus.cardano.infra.UnsupportedSubscriptionException](h.require(request))
     }
+    private def input(txByte: Byte, index: Int): TransactionInput = {
+        val bytes = new Array[Byte](32)
+        bytes(31) = txByte
+        TransactionInput(TransactionHash.fromByteString(ByteString.fromArray(bytes)), index)
+    }
+
+    private def output(): TransactionOutput = TransactionOutput(alice, Value.ada(3))
+
+    /** A block whose single transaction creates and spends the given UTxOs. */
+    private def blockWith(n: Long, created: Utxos, spent: Utxos): AppliedBlock =
+        AppliedBlock(
+          point(n),
+          n,
+          Seq(AppliedTransaction(Transaction.empty, created, spent))
+        )
+
+    test("the seed is wound back over blocks that have not been delivered yet") {
+        val h = hub(caps(rollbackHorizon = Some(3)))
+        val fresh = input(1, 0)
+        (1L to 4L).foreach(n => h.applyBlock(block(n)))
+        // Block 5 creates `fresh`, and a depth-2 subscription has not been delivered it yet.
+        h.applyBlock(blockWith(5L, created = Map(fresh -> output()), spent = Map.empty))
+
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        h.registerUtxo(
+          h.nextSubscriptionId(),
+          addressQuery(UtxoEventType.all),
+          SubscriptionOptions(includeExistingUtxos = true, confirmations = 2),
+          mailbox,
+          // The snapshot describes the chain now, so it contains `fresh`.
+          Map(fresh -> output())
+        )
+
+        assert(
+          drain(mailbox).isEmpty,
+          "block 5 will be delivered later and will report this UTxO's creation itself; seeding " +
+              "it as well would report the same UTxO twice"
+        )
+    }
+
+    test("a UTxO spent in an undelivered block is restored to the seed") {
+        val h = hub(caps(rollbackHorizon = Some(3)))
+        val old = input(2, 0)
+        (1L to 4L).foreach(n => h.applyBlock(block(n)))
+        // Block 5 spends a UTxO that existed before the subscription's watermark.
+        h.applyBlock(blockWith(5L, created = Map.empty, spent = Map(old -> output())))
+
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        h.registerUtxo(
+          h.nextSubscriptionId(),
+          addressQuery(UtxoEventType.all),
+          SubscriptionOptions(includeExistingUtxos = true, confirmations = 2),
+          mailbox,
+          // Already spent, so the current snapshot does not contain it.
+          Map.empty
+        )
+
+        assert(
+          drain(mailbox).collect { case UtxoEvent.Created(u, _, _) => u.input } == List(old),
+          "block 5's Spent is still to be delivered, and a Spent for a UTxO the subscriber was " +
+              "never told about is not something it can act on"
+        )
+    }
+
+    // Specification rather than regression: with the rewind removed the snapshot is already
+    // empty here, so this one pins the intended rule without being able to catch its loss.
+    test("a UTxO created and spent within the undelivered window is in neither") {
+        val h = hub(caps(rollbackHorizon = Some(3)))
+        val ephemeral = input(3, 0)
+        (1L to 4L).foreach(n => h.applyBlock(block(n)))
+        h.applyBlock(blockWith(5L, created = Map(ephemeral -> output()), spent = Map.empty))
+        h.applyBlock(blockWith(6L, created = Map.empty, spent = Map(ephemeral -> output())))
+
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        h.registerUtxo(
+          h.nextSubscriptionId(),
+          addressQuery(UtxoEventType.all),
+          SubscriptionOptions(includeExistingUtxos = true, confirmations = 2),
+          mailbox,
+          Map.empty
+        )
+
+        assert(
+          drain(mailbox).isEmpty,
+          "it did not exist at the watermark, and both its creation and its spend are still to " +
+              "be delivered"
+        )
+    }
+
+    // Likewise a guard, not a regression test: at depth 0 there is nothing pending, so the two
+    // implementations agree by construction. It pins that the rewind stays a no-op there.
+    test("with no confirmation gate the seed is the snapshot unchanged") {
+        val h = hub()
+        val u = input(4, 0)
+        h.applyBlock(blockWith(1L, created = Map(u -> output()), spent = Map.empty))
+
+        val mailbox = Mailbox.delta[UtxoEvent]()
+        h.registerUtxo(
+          h.nextSubscriptionId(),
+          addressQuery(UtxoEventType.all),
+          SubscriptionOptions(includeExistingUtxos = true),
+          mailbox,
+          Map(u -> output())
+        )
+
+        assert(
+          drain(mailbox).collect { case UtxoEvent.Created(x, _, _) => x.input } == List(u),
+          "nothing is pending at depth 0, so the rewind must be a no-op"
+        )
+    }
+
 }

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionSupportTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionSupportTest.scala
@@ -20,7 +20,7 @@ class SubscriptionSupportTest extends AnyFunSuite {
     private val blockfrostLike = StreamCapabilities(
       kinds = SubscriptionKind.all,
       pushdown = Set(PushdownKind.Address, PushdownKind.Asset),
-      scanning = ScanCost.Metered,
+      scanning = ScanSupport.Metered,
       replay = ReplaySupport.Scoped(Set(PushdownKind.Address, PushdownKind.Asset)),
       rollbackHorizon = Some(50),
       maxConfirmations = Some(100),
@@ -30,7 +30,7 @@ class SubscriptionSupportTest extends AnyFunSuite {
     /** An in-process provider: the whole ledger is in memory, so nothing costs extra. */
     private val inMemory = blockfrostLike.copy(
       pushdown = PushdownKind.all,
-      scanning = ScanCost.Free,
+      scanning = ScanSupport.Free,
       replay = ReplaySupport.NoReplay,
       maxConfirmations = None
     )
@@ -169,4 +169,51 @@ class SubscriptionSupportTest extends AnyFunSuite {
         )
         assert(verdict == SubscriptionSupport.Unindexed)
     }
+    test("a provider that cannot scan refuses, rather than letting a caller consent") {
+        val lookupOnly = StreamCapabilities(
+          kinds = SubscriptionKind.all,
+          pushdown = Set(PushdownKind.Address),
+          scanning = ScanSupport.Unsupported,
+          replay = ReplaySupport.NoReplay,
+          rollbackHorizon = None,
+          maxConfirmations = None,
+          idleSignals = true
+        )
+        val everyTransaction = SubscriptionRequest.Transaction(
+          TransactionQuery.All,
+          // Consent given — and it must not help, because the scan is not expensive, it is
+          // impossible. Classifying this as Unindexed would accept the subscription and then
+          // deliver nothing, forever, with no error.
+          SubscriptionOptions(allowUnindexedScan = true)
+        )
+        assert(
+          SubscriptionSupport
+              .of(everyTransaction, lookupOnly)
+              .isInstanceOf[
+                SubscriptionSupport.Unsupported
+              ],
+          "a lookup-only provider serves exactly what it can push down and refuses the rest"
+        )
+    }
+
+    test("a metered provider still accepts the same request when the caller consents") {
+        val metered = StreamCapabilities(
+          kinds = SubscriptionKind.all,
+          pushdown = Set(PushdownKind.Address),
+          scanning = ScanSupport.Metered,
+          replay = ReplaySupport.NoReplay,
+          rollbackHorizon = None,
+          maxConfirmations = None,
+          idleSignals = true
+        )
+        val everyTransaction = SubscriptionRequest.Transaction(
+          TransactionQuery.All,
+          SubscriptionOptions(allowUnindexedScan = true)
+        )
+        assert(
+          SubscriptionSupport.of(everyTransaction, metered) == SubscriptionSupport.Unindexed,
+          "Unsupported must not have swallowed the case it was carved out of"
+        )
+    }
+
 }

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionSupportTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/stream/SubscriptionSupportTest.scala
@@ -216,4 +216,43 @@ class SubscriptionSupportTest extends AnyFunSuite {
         )
     }
 
+    test("a provider that does not declare TransactionStatus refuses to follow a transaction") {
+        val noStatus = StreamCapabilities(
+          kinds = Set(SubscriptionKind.Utxo, SubscriptionKind.Transaction),
+          pushdown = Set(PushdownKind.Address),
+          scanning = ScanSupport.Unsupported,
+          replay = ReplaySupport.NoReplay,
+          rollbackHorizon = None,
+          maxConfirmations = None,
+          idleSignals = true
+        )
+        val request = SubscriptionRequest.TransactionStatus(someTxHash)
+        assert(
+          SubscriptionSupport.of(request, noStatus).isInstanceOf[SubscriptionSupport.Unsupported],
+          "a provider that only observes the sources it was asked to watch cannot say what " +
+              "happened to an arbitrary hash, and reporting Pending forever would be worse than " +
+              "refusing — the subscriber could not tell that apart from a transaction that has " +
+              "genuinely not landed"
+        )
+    }
+
+    test("following a transaction is a lookup, so it is Indexed wherever it is served") {
+        val withStatus = StreamCapabilities(
+          kinds = SubscriptionKind.all,
+          pushdown = Set(PushdownKind.Address),
+          // Even where no scan is possible at all: a hash is the most direct lookup there is.
+          scanning = ScanSupport.Unsupported,
+          replay = ReplaySupport.NoReplay,
+          rollbackHorizon = None,
+          maxConfirmations = None,
+          idleSignals = true
+        )
+        assert(
+          SubscriptionSupport.of(
+            SubscriptionRequest.TransactionStatus(someTxHash),
+            withStatus
+          ) == SubscriptionSupport.Indexed
+        )
+    }
+
 }

--- a/scalus-testkit/jvm/src/main/scala/scalus/testing/stream/StreamProviderConformance.scala
+++ b/scalus-testkit/jvm/src/main/scala/scalus/testing/stream/StreamProviderConformance.scala
@@ -351,6 +351,8 @@ abstract class StreamProviderConformance extends AnyFunSuite {
             )
         case SubscriptionKind.Block =>
             SubscriptionRequest.Block(BlockQuery.All, SubscriptionOptions())
+        case SubscriptionKind.TransactionStatus =>
+            SubscriptionRequest.TransactionStatus(f.payTo(f.freshAddress(), Value.ada(1)))
 
     /** Every shape worth classifying: indexed, unindexed, and unindexed-but-accepted. */
     private def candidateRequests(f: StreamConformanceFixture): Seq[SubscriptionRequest] = {
@@ -380,6 +382,8 @@ abstract class StreamProviderConformance extends AnyFunSuite {
                 case SubscriptionRequest.Transaction(q, o) =>
                     p.subscribeTransactionQuery(q, o).cancel()
                 case SubscriptionRequest.Block(q, o) => p.subscribeBlockQuery(q, o).cancel()
+                case SubscriptionRequest.TransactionStatus(h) =>
+                    p.subscribeTransactionStatus(h).cancel()
             Right(())
         catch case e: UnsupportedSubscriptionException => Left(e)
     }


### PR DESCRIPTION
Groundwork for M2 of the streaming-interface proposal: the parts of a Blockfrost provider that are
not the provider. No `StreamingBlockfrostProvider` yet — this is the hub work, the seam, and the
polling follower, each landed with the capability model it needs.

Ordering decision recorded along the way: **Blockfrost first, Ogmios behind it.** The analysis for
the alternative is kept in the design note, because the seam below means the Ogmios follower can be
added later without disturbing any of this.

## The problem this starts from

The hub was built for a provider that holds whole blocks. Blockfrost's entire cost model is that it
does *not* — its cheap path is per-address endpoints, so what it learns about a height is only ever
"what these sources did in it".

Feeding such a block to the hub as it stood would have delivered it to every subscription, told the
unrelated ones "nothing here for you" as an `Idle`, and advanced them past a height nobody had
examined on their behalf — after which the real events for that height fall below the watermark and
can never be delivered. Silently, and undetectably from the subscriber's side.

## What's here

**`BlockCoverage` on `AppliedBlock`.** `Complete` (the default, so every M1 path is untouched) or
`Sources(...)` naming what was probed. Delivery is gated on the subscription's query being
answerable from it, with the same recursion as `SubscriptionSupport.isIndexed`: a union needs every
arm, an intersection needs one, since the rest post-filters data already in hand. Pruning moves from
entry count to a height window.

Backfill is deliberately not representable, and `AppliedBlock` says so: a provider that runs out of
request budget mid-height must defer the whole height rather than come back for what it skipped.

**A `ChainFollower` seam.** A follower emits normalised `ChainEvent`s into a `ScalusAsyncSource`,
and one shared `HubDriver` pumps them into the hub. Everything subscription correctness depends on
stays in the hub, so Blockfrost, Ogmios and UTxORPC will differ only in the follower. Events are
normalised rather than backend-shaped on purpose — a source emitting wire types would force a branch
per backend into the driver and the sharing would evaporate.

**`BlockfrostChainFollower`.** Polls `/blocks/{hash}/next`, which yields progress *and* reorg
detection from the request it was making anyway: a 404 means the block it last reported is off-chain.
Per new block it polls `/addresses/{a}/transactions` scoped to that height, once per watched address,
so cost scales with addresses watched rather than chain activity. The poll interval is a parameter,
and `delay` is injected so tests drive the loop without real time.

Reorgs are detected, not reconciled — the ring walk is not in the light driver. It fails with
`ResyncRequiredException` so a subscriber learns its view is untrustworthy rather than diverging
silently, and `rollbackHorizon = None` stays truthful.

## Three capability-model changes

Each closes a case where a provider could accept something and then deliver nothing, forever, with
no error. All are free right now: the package is absent from the last published artifact, so MiMa has
nothing to compare — which is exactly the window the proposal's "unfrozen for one or two releases"
decision reserved.

- **`ScanCost` → `ScanSupport`, gaining `Unsupported`.** A provider built out of per-source lookups
  has no request sequence that answers "every transaction" *at any price*, so classifying it as
  `Metered` let a caller consent via `allowUnindexedScan` to an impossibility. The refusal stays
  derived from the declaration rather than hand-written in the provider, which is what keeps "a
  provider cannot accept what it did not advertise" true by construction.
- **`SubscriptionKind.TransactionStatus`.** A provider observing only its watched sources cannot say
  what happened to an arbitrary hash. Undeclared, it reported `Pending` forever for a transaction
  confirmed on chain — indistinguishable, to the subscriber, from one that genuinely had not landed.
- **`watch` returns the `ChainPoint` its source set takes effect from.** Registering a subscription
  and telling the follower to watch its sources are two steps, and a block processed between them is
  covered by neither. A `ChainPoint` rather than a height because heights are only unique within a
  fork, and this seam exists for followers that emit `RollBackward`.

## A pre-existing bug found on the way

Seeding and live delivery overlapped whenever `confirmations > 0`. A snapshot describes the chain
now, but the watermark starts at `tip - depth`, so a UTxO created in one of the pending blocks
arrived twice — once in the seed, once when the block was released — and one created before the
window and spent inside it was missing from the snapshot, handing the subscriber a `Spent` for
something it never saw created.

The hub already holds those blocks and `AppliedTransaction.spent` carries resolved outputs, so the
snapshot is now wound back over them: drop what they created, restore what they consumed. A UTxO both
created and spent inside the window belongs to neither. At the default depth there are no pending
blocks and this is the snapshot unchanged, which is why nothing had caught it.

## Reviewing

Two rounds of `/code-review` ran against this branch and both found real bugs; the fixes are separate
commits (`5c6dc1455`, `e0cfadd93`) rather than folded in, so the defects are legible. Worth knowing:

- The follower originally declared coverage over its whole watched set while probing only address
  leaves — the exact silent loss `BlockCoverage` exists to prevent, committed by the code reporting
  the coverage.
- `HubDriver.close()` swallowed the follower's end-of-stream, leaving every subscriber parked on a
  promise that would never complete.
- A bounded producer mailbox that had overflowed kept the poll loop running, spending metered quota
  indefinitely on a feed nobody could read.

Several test sets were also shown to pass against the broken code they claimed to cover. Where a test
still cannot catch its own loss, it now says so in a comment rather than reading as protection it does
not provide. The load-bearing ones are negative-controlled: reverting the fix fails the test.

## Testing

875 `scalus-cardano-ledger`, 108 `scalus-testkit`, format check and MiMa clean, rebased on
`b98a2d77c`.

## Not in scope

`StreamingBlockfrostProvider` itself. The design note records what the wiring must get right:
`kinds` without `Block` (a driver that never produces a whole block cannot serve block
subscriptions), refusing `Unindexed` outright, and ordering `watch` → snapshot → register so the
seed covers the block the watch could not.
