### PR TITLE
fix: an Or that cannot evaluate one side is not a union

### DIFF
--- a/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/BlockfrostProvider.scala
+++ b/scalus-cardano-ledger/shared/src/main/scala/scalus/cardano/node/BlockfrostProvider.scala
@@ -748,11 +748,7 @@ class BlockfrostProvider(
                 val leftFuture = evalSource(left)
                 val rightFuture = evalSource(right)
                 leftFuture.zip(rightFuture).map { case (leftResult, rightResult) =>
-                    (leftResult, rightResult) match
-                        case (Right(l), Right(r)) => Right(l ++ r)
-                        case (Right(l), _)        => Right(l)
-                        case (_, Right(r))        => Right(r)
-                        case (Left(e), _)         => Left(e)
+                    BlockfrostProvider.combineOr(leftResult, rightResult)
                 }
             case UtxoSource.And(left, right) =>
                 // Execute both sources in parallel (both must be fetched for intersection)
@@ -830,14 +826,9 @@ class BlockfrostProvider(
                 val leftFuture = evalQuery(UtxoQuery.propagate(left, limit, minTotal))
                 val rightFuture = evalQuery(UtxoQuery.propagate(right, limit, minTotal))
                 leftFuture.zip(rightFuture).map { case (leftResult, rightResult) =>
-                    (leftResult, rightResult) match
-                        case (Right(l), Right(r)) =>
-                            Right(UtxoQuery.applyPagination(l ++ r, limit, offset, minTotal))
-                        case (Right(l), _) =>
-                            Right(UtxoQuery.applyPagination(l, limit, offset, minTotal))
-                        case (_, Right(r)) =>
-                            Right(UtxoQuery.applyPagination(r, limit, offset, minTotal))
-                        case (Left(e), _) => Left(e)
+                    BlockfrostProvider
+                        .combineOr(leftResult, rightResult)
+                        .map(UtxoQuery.applyPagination(_, limit, offset, minTotal))
                 }
 
         evalQuery(query)
@@ -1171,6 +1162,30 @@ object BlockfrostProvider {
         val refHashes = parsed.collect { case ((input, _), Some(hash)) => input -> hash }.toMap
         (utxos, refHashes)
     }
+
+    /** Combine the two halves of an `Or`, which is a union and therefore needs both.
+      *
+      * A failure means "this side could not be evaluated", not "this side is empty", and the two
+      * are not interchangeable: `UtxoSource.FromPaymentCredential` always fails against Blockfrost,
+      * which has no reverse index for it, so `credential || address` used to answer with the
+      * address's UTxOs alone and report success. The caller could not tell that half its query had
+      * never run.
+      *
+      * So any failure propagates, matching `And` in the same evaluator and the union `Or` is
+      * documented to compute. When both sides fail the left error is reported, again as `And` does.
+      *
+      * Note this makes an `Or` no more available than its least available side: `FromInputs`
+      * reports `NotFound` when an input is missing rather than returning an empty set, so
+      * `inputs || address` now fails where it used to fall back. That is the honest answer to a
+      * union whose operand could not be computed; a caller wanting a fallback wants two queries.
+      */
+    private[node] def combineOr(
+        left: Either[UtxoQueryError, Utxos],
+        right: Either[UtxoQueryError, Utxos]
+    ): Either[UtxoQueryError, Utxos] = (left, right) match
+        case (Right(l), Right(r)) => Right(l ++ r)
+        case (Left(e), _)         => Left(e)
+        case (_, Left(e))         => Left(e)
 
     /** Extract the optional `reference_script_hash` field from a UTxO/output JSON object. */
     private[node] def referenceScriptHash(json: ujson.Value): Option[ScriptHash] =

--- a/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/BlockfrostOrCombineTest.scala
+++ b/scalus-cardano-ledger/shared/src/test/scala/scalus/cardano/node/BlockfrostOrCombineTest.scala
@@ -1,0 +1,77 @@
+package scalus.cardano.node
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.cardano.address.{Address, Network, ShelleyAddress, ShelleyDelegationPart, ShelleyPaymentPart}
+import scalus.cardano.ledger.*
+import scalus.uplc.builtin.ByteString
+
+/** `Or` is documented as the union of two sources, so it needs both of them.
+  *
+  * It used to answer with whichever half succeeded, as a `Right`. That made
+  * `FromPaymentCredential(c) || FromAddress(a)` return `a`'s UTxOs and report success - and
+  * `FromPaymentCredential` *always* fails against Blockfrost, which has no reverse index from a
+  * payment credential to the addresses carrying it. So that query silently answered a different
+  * question than the one asked, every time, with nothing in the result to say so.
+  */
+class BlockfrostOrCombineTest extends AnyFunSuite {
+
+    private def addressAt(seed: String): Address = ShelleyAddress(
+      Network.Testnet,
+      ShelleyPaymentPart.Key(Hash[Blake2b_224, HashPurpose.KeyHash](ByteString.fromHex(seed * 28))),
+      ShelleyDelegationPart.Null
+    )
+
+    private def utxoAt(seed: String, index: Int, coin: Long): Utxos = Map(
+      TransactionInput(TransactionHash.fromHex(seed * 32), index) ->
+          TransactionOutput(addressAt(seed), Value(Coin(coin)))
+    )
+
+    private val left = utxoAt("11", 0, 1_000_000L)
+    private val right = utxoAt("22", 1, 2_000_000L)
+
+    private val notSupported = UtxoQueryError.NotSupported(
+      UtxoQuery(
+        UtxoSource.FromPaymentCredential(Credential.KeyHash(AddrKeyHash.fromHex("33" * 28)))
+      ),
+      "Blockfrost has no reverse index from a payment credential to its addresses"
+    )
+    private val networkError = UtxoQueryError.NetworkError("connection reset", None)
+
+    test("both sides succeeding gives the union") {
+        val combined = BlockfrostProvider.combineOr(Right(left), Right(right))
+        assert(combined == Right(left ++ right))
+        assert(combined.toOption.get.size == 2)
+    }
+
+    test("an unsupported left side fails the query instead of answering with the right side") {
+        // The case Ruslan reported: `credential || address` used to come back as the address's
+        // UTxOs, indistinguishable from a genuine union that happened to hold only those.
+        val combined = BlockfrostProvider.combineOr(Left(notSupported), Right(right))
+        assert(combined == Left(notSupported))
+    }
+
+    test("an unsupported right side fails the query too") {
+        val combined = BlockfrostProvider.combineOr(Right(left), Left(notSupported))
+        assert(combined == Left(notSupported))
+    }
+
+    test("a transient failure on either side also fails, rather than halving the answer") {
+        // A network error is not "this side is empty" either. Returning the reachable half as a
+        // success would leave a caller doing coin selection against an arbitrary subset of its
+        // own UTxOs, and no way to notice.
+        assert(BlockfrostProvider.combineOr(Left(networkError), Right(right)) == Left(networkError))
+        assert(BlockfrostProvider.combineOr(Right(left), Left(networkError)) == Left(networkError))
+    }
+
+    test("when both sides fail the left error is the one reported") {
+        assert(
+          BlockfrostProvider.combineOr(Left(notSupported), Left(networkError)) == Left(notSupported)
+        )
+    }
+
+    test("the union is by input, so a UTxO present on both sides appears once") {
+        val combined = BlockfrostProvider.combineOr(Right(left), Right(left))
+        assert(combined == Right(left))
+        assert(combined.toOption.get.size == 1)
+    }
+}


### PR DESCRIPTION
Found by @rssh reviewing #360:

> `FromPaymentCredential(c) || FromAddress(a)` — silently return address(a)
>
> We need or throw exception or rework query generation (i.e. `UtxoQuery.Or`)

`BlockfrostProvider` evaluated both halves of an `Or` and, when one failed, returned the other as a
success:

```scala
case (Right(l), Right(r)) => Right(l ++ r)
case (Right(l), _)        => Right(l)   // right failed - answers with left, as success
case (_, Right(r))        => Right(r)   // left failed  - answers with right, as success
```

`UtxoSource.Or` is documented as *"returns union of UTxOs from both"*. A union missing an operand is
not a union, and the caller got a `Right` with nothing in it to say half the query had never run.

It mattered most where it was guaranteed rather than occasional: `FromPaymentCredential` **always**
fails against Blockfrost, which has no reverse index from a payment credential to the addresses
carrying it — the evaluator returns `NotSupported` by design. So `credential || address` silently
answered with the address's UTxOs alone, every single time, and looked like a successful union that
happened to contain only those.

## The change

A failure means "this side could not be evaluated", not "this side is empty", and the two are not
interchangeable. Both `Or` sites now propagate, which is what `And` in the same evaluator already
did — `Or` was the odd one out in its own file.

The combination moved to `BlockfrostProvider.combineOr`, alongside the file's other pure helpers
(`referenceScriptHash`, `buildPlutusScript`). That is also what made it testable: the original lived
in a nested `def` inside `findUtxos` and could not be reached without a network double.

## Tests

Six, in `BlockfrostOrCombineTest`, and verified discriminating rather than merely green: reverting
`combineOr` to the old logic fails exactly the three that pin the swallowing behaviour. The other
three — union, deduplication by input, and which error wins when both sides fail — pass either way,
because they do not concern the bug.

## One consequence worth accepting knowingly

An `Or` is now no more available than its least available side. `FromInputs` reports `NotFound` for a
missing input rather than returning an empty set, so `inputs || address` now fails where it used to
fall back to the address.

That is the honest answer for a union whose operand could not be computed, and a caller that wants
fallback semantics wants two queries rather than an `Or`. But it is a behaviour change, so it is
called out here and in the commit message rather than left to be discovered.

`ci-jvm`, `ci-js` and `ci-native` are green.

The other half of that review — the `Long` range guard on `Value` — was considered and deliberately
dropped: the values needed are three orders of magnitude beyond the max ADA supply.
