### PR TITLE
fix(lowering): choose between constructors of a function-holding sum at runtime

### DIFF
--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrOnlyEmitter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/ProductCaseUplcConstrOnlyEmitter.scala
@@ -29,7 +29,17 @@ object ProductCaseUplcConstrOnlyEmitter extends SirTypeUplcGenerator {
     override def upcastOne(input: LoweredValue, targetType: SIRType, pos: SIRPosition)(using
         LoweringContext
     ): LoweredValue = {
-        TypeRepresentationProxyLoweredValue(input, targetType, input.representation, pos)
+        // Upcast to the parent sum: the bytes are already `Constr(tag, fields)`, which is exactly
+        // the shape of a `SumUplcConstr`, so only the representation label changes. Keeping the
+        // `ProdUplcConstr` label on a sum-typed value is what `lvIfThenElse` guards against
+        // (`GUARD lvIfThenElse ... Sum type X with ProdUplcConstr`): downstream `genMatch` on
+        // the sum dispatches on the representation. Mirrors `ProductCaseUplcConstrEmitter`;
+        // unlike it, no Data-side conversion is needed here - a Fun-bearing value is always in
+        // UplcConstr form.
+        val targetRepr =
+            if SIRType.isSum(targetType) then SumUplcConstrOps.buildSumUplcConstr(targetType)
+            else input.representation
+        TypeRepresentationProxyLoweredValue(input, targetType, targetRepr, pos)
     }
 
     override def genConstrLowered(

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrCommon.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrCommon.scala
@@ -19,6 +19,38 @@ trait SumCaseUplcConstrCommon extends SirTypeUplcGenerator {
     ): LoweredValueRepresentation =
         SumUplcConstrOps.buildSumUplcConstr(tp)
 
+    /** `constr` with a CaseClass `tp`, as `ProdUplcConstrOps.genConstr` requires.
+      *
+      * A nullary enum case (`case Skip`) and a constructor reached through `dispatchNil` carry the
+      * *sum* type as `constr.tp` (possibly `Annotated`, with caller-supplied substituted args).
+      * Rebuild the CaseClass form for `constr.name` with that sum preserved as its parent, rather
+      * than dropping it via the static `decl.constrType(name)` lookup (which would substitute back
+      * to the abstract decl typevars).
+      */
+    protected def withCaseClassTp(constr: SIR.Constr): SIR.Constr = {
+        val effectiveTp =
+            if SIRType.isProd(constr.tp) then constr.tp
+            else if SIRType.isSum(constr.tp) then
+                preservedParentCaseClassForm(constr.tp, constr.data, constr.name)
+            else constr.data.constrType(constr.name)
+        constr.copy(tp = effectiveTp)
+    }
+
+    /** Build a CaseClass form for `ctorName` using `parent` as its parent field, preserving any
+      * `Annotated`/substituted args on `parent`. The constructor's own shape (typeParams, typeArgs)
+      * comes from `decl.constrType(ctorName)`; only the parent reference is swapped.
+      */
+    private def preservedParentCaseClassForm(
+        parent: SIRType,
+        decl: scalus.compiler.sir.DataDecl,
+        ctorName: String
+    ): SIRType = decl.constrType(ctorName) match
+        case SIRType.TypeLambda(params, SIRType.CaseClass(c, args, _)) =>
+            SIRType.TypeLambda(params, SIRType.CaseClass(c, args, Some(parent)))
+        case SIRType.CaseClass(c, args, _) =>
+            SIRType.CaseClass(c, args, Some(parent))
+        case other => other
+
     /** Template method: `ProdUplcConstr` is always lifted into a single-entry `SumUplcConstr`
       * parent; everything else is delegated to `upcastOneOther`.
       *

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrEmitter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrEmitter.scala
@@ -59,36 +59,8 @@ object SumCaseUplcConstrEmitter extends SumCaseUplcConstrCommon {
         constr: SIR.Constr,
         loweredArgs: scala.List[LoweredValue],
         optTargetType: Option[SIRType]
-    )(using lctx: LoweringContext): LoweredValue = {
-        // `ProdUplcConstrOps.genConstr` needs a CaseClass tp. After `dispatchNil` `constr.tp` may be a
-        // sum target (possibly `Annotated`) carrying caller-supplied substituted args — preserve
-        // them as the rebuilt CaseClass's parent rather than dropping them via the static
-        // `decl.constrType(name)` lookup (which would substitute back to abstract decl typevars).
-        val effectiveTp =
-            if SIRType.isProd(constr.tp) then constr.tp
-            else if SIRType.isSum(constr.tp) then
-                preservedParentCaseClassForm(constr.tp, constr.data, constr.name)
-            else constr.data.constrType(constr.name)
-        ProdUplcConstrOps.genConstr(
-          constr.copy(tp = effectiveTp),
-          loweredArgs
-        )
-    }
-
-    /** Build a CaseClass form for `ctorName` using `parent` as its parent field, preserving any
-      * `Annotated`/substituted args on `parent`. The constructor's own shape (typeParams, typeArgs)
-      * comes from `decl.constrType(ctorName)`; only the parent reference is swapped.
-      */
-    private def preservedParentCaseClassForm(
-        parent: SIRType,
-        decl: scalus.compiler.sir.DataDecl,
-        ctorName: String
-    ): SIRType = decl.constrType(ctorName) match
-        case SIRType.TypeLambda(params, SIRType.CaseClass(c, args, _)) =>
-            SIRType.TypeLambda(params, SIRType.CaseClass(c, args, Some(parent)))
-        case SIRType.CaseClass(c, args, _) =>
-            SIRType.CaseClass(c, args, Some(parent))
-        case other => other
+    )(using lctx: LoweringContext): LoweredValue =
+        ProdUplcConstrOps.genConstr(withCaseClassTp(constr), loweredArgs)
 
     override def genSelect(sel: SIR.Select, loweredScrutinee: LoweredValue)(using
         lctx: LoweringContext

--- a/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrOnlyEmitter.scala
+++ b/scalus-core/shared/src/main/scala/scalus/compiler/sir/lowering/typegens/SumCaseUplcConstrOnlyEmitter.scala
@@ -42,9 +42,8 @@ object SumCaseUplcConstrOnlyEmitter extends SumCaseUplcConstrCommon {
         constr: SIR.Constr,
         loweredArgs: scala.List[LoweredValue],
         optTargetType: Option[SIRType]
-    )(using lctx: LoweringContext): LoweredValue = {
-        ProdUplcConstrOps.genConstr(constr, loweredArgs)
-    }
+    )(using lctx: LoweringContext): LoweredValue =
+        ProdUplcConstrOps.genConstr(withCaseClassTp(constr), loweredArgs)
 
     override def genSelect(sel: SIR.Select, loweredScrutinee: LoweredValue)(using
         lctx: LoweringContext

--- a/scalus-core/shared/src/test/scala/scalus/uplc/SumWithClosureBranchJoinTest.scala
+++ b/scalus-core/shared/src/test/scala/scalus/uplc/SumWithClosureBranchJoinTest.scala
@@ -1,0 +1,78 @@
+package scalus.uplc
+
+import org.scalatest.funsuite.AnyFunSuite
+import scalus.*
+import scalus.cardano.onchain.plutus.prelude.*
+import scalus.compiler.{Compile, Options}
+import scalus.uplc.builtin.Data
+import scalus.uplc.eval.PlutusVM
+
+/** A sum type holding a function has no Data form: it is UplcConstr-only. */
+enum ClosureStep:
+    case Run(f: BigInt => BigInt)
+    case Skip
+
+sealed trait ClosureShape extends Product with Serializable
+case class ClosureA(f: BigInt => BigInt) extends ClosureShape
+case class ClosureB(n: BigInt) extends ClosureShape
+
+@Compile
+object SumWithClosureFixtures {
+    def enumIf(d: Data): Unit = {
+        val n = d.to[BigInt]
+        val s: ClosureStep = if n > 0 then ClosureStep.Run(x => x + 1) else ClosureStep.Skip
+        val r = s match
+            case ClosureStep.Run(f) => f(n)
+            case ClosureStep.Skip   => n
+        require(r >= 0, "neg")
+    }
+
+    def enumMatch(d: Data): Unit = {
+        val n = d.to[BigInt]
+        val s: ClosureStep = n match
+            case x if x > 0 => ClosureStep.Run(x => x + 1)
+            case _          => ClosureStep.Skip
+        val r = s match
+            case ClosureStep.Run(f) => f(n)
+            case ClosureStep.Skip   => n
+        require(r >= 0, "neg")
+    }
+
+    def traitIf(d: Data): Unit = {
+        val n = d.to[BigInt]
+        val t: ClosureShape = if n > 0 then ClosureA(x => x + 1) else ClosureB(n)
+        val r = t match
+            case ClosureA(f) => f(n)
+            case ClosureB(m) => m
+        require(r >= 0, "neg")
+    }
+}
+
+/** Choosing between two constructors of a function-holding sum type at runtime. Building through a
+  * single constructor already works; the join of two different constructors did not.
+  */
+class SumWithClosureBranchJoinTest extends AnyFunSuite {
+    private given PlutusVM = PlutusVM.makePlutusV3VM()
+    private val one = Term.Const(Constant.Data(Data.I(1)))
+    private val zero = Term.Const(Constant.Data(Data.I(0)))
+
+    private def runsOnBothBranches(compiled: PlutusV3[Data => Unit]): Unit = {
+        val program = compiled.program
+        assert((program $ one).evaluateDebug.isSuccess, "Run branch")
+        assert((program $ zero).evaluateDebug.isSuccess, "Skip branch")
+    }
+
+    test("if between two constructors of a function-holding enum") {
+        runsOnBothBranches(PlutusV3.compile(SumWithClosureFixtures.enumIf)(using Options.release))
+    }
+
+    test("match returning two constructors of a function-holding enum") {
+        runsOnBothBranches(
+          PlutusV3.compile(SumWithClosureFixtures.enumMatch)(using Options.release)
+        )
+    }
+
+    test("if between two case classes of a function-holding sealed trait") {
+        runsOnBothBranches(PlutusV3.compile(SumWithClosureFixtures.traitIf)(using Options.release))
+    }
+}

--- a/scalus-site/content/language-guide/support.mdx
+++ b/scalus-site/content/language-guide/support.mdx
@@ -33,10 +33,7 @@ Below is a comprehensive list of what Scala features are currently supported in 
 * functions stored in data types: a case class, enum, `List` or `Option` may hold a function
   value (Aiken forbids this; Plinth allows it). Such a value has no `Data` form, so it cannot be a
   datum or redeemer, and it needs UPLC 1.1.0 – PlutusV3, or PlutusV1/V2 from protocol version 11
-  (van Rossem) on. One known gap: choosing between two constructors of a function-holding enum at
-  runtime (`if c then Run(f) else Skip`, or a `match` returning different constructors) does not
-  lower yet; build the value through one constructor, or dispatch on the condition after
-  matching instead
+  (van Rossem) on
 * `inline` vals, functions and macros in general
 * implicit conversions
 * opaque types (non top-level) and type aliases


### PR DESCRIPTION
`if c then Run(f) else Skip` on an enum whose cases hold a function, or a `match` returning different constructors of one, failed to lower. Building the value through a single constructor worked, so this only showed up when the constructor is chosen at runtime.

Two gaps in the Fun-bearing (`*Only`) emitters. Each is a normalisation step the Data-compatible sibling already had, which is why the same shapes work for `@UplcRepr(UplcConstr)` types without functions.

## 1. Construction of a nullary case

`SumCaseUplcConstrOnlyEmitter.genConstrLowered` passed `constr` straight to `ProdUplcConstrOps.genConstr`, which needs a CaseClass `tp`. A nullary enum case (`case Skip`) carries the *sum* type as its `tp`, so it failed with `Expected case class type, got X`. `SumCaseUplcConstrEmitter` did the rebuild-as-CaseClass inline; it is now `SumCaseUplcConstrCommon.withCaseClassTp`, used by both emitters.

## 2. Upcast to the parent sum

`ProductCaseUplcConstrOnlyEmitter.upcastOne` kept the input's `ProdUplcConstr` label when upcasting to the parent sum. The value reached the join typed as the sum but labelled as a product, and `lvIfThenElse`'s guard fired (`GUARD lvIfThenElse ... Sum type X with ProdUplcConstr`). Both the plugin's explicit `Cast` to the `if` type and `lvIfThenElse`'s own `maybeUpcast` reach this path. It now relabels to `SumUplcConstrOps.buildSumUplcConstr(targetType)`, as `ProductCaseUplcConstrEmitter` does. The bytes are already `Constr(tag, fields)`, so only the label changes; unlike the Data-compatible emitter there is no Data-side conversion to consider, a Fun-bearing value is always in UplcConstr form.

I verified the two independently: fix 1 alone moved the enum tests from the construction error to the join guard, fix 2 then cleared all three.

## Tests

`SumWithClosureBranchJoinTest`: `if` and `match` on an enum, `if` on a sealed trait, each asserting **both branches evaluate**, not just lower.

`jvm/test` + `mima` green: core 3735, examples 591, all modules. These emitters sit under every `@UplcRepr(UplcConstr)` type, so the full run matters.

## Docs

`support.mdx` recorded this as a known gap in the "functions stored in data types" entry (added in 47a022464); that sentence is removed.

## Context

Found while checking whether Scalus supports closures in data types (it does; Aiken forbids them, Plinth allows them). Probing nine shapes showed everything works except runtime choice between constructors of a function-holding sum, which is what this fixes.
