### PR TITLE
fix(plugin): preserve guard evaluation and reject alternative aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,13 @@
 
 ### Fixed
 
+- Constructor-pattern fallbacks no longer repeat wildcard guards that have already failed.
+  This preserves trace order and avoids duplicate execution costs; affected scripts may change
+  size, execution budgets, and hashes after recompilation.
+- Unsupported aliases on alternative patterns, such as `x @ ("a" | "b")`, now produce a
+  positioned diagnostic instead of a misleading forward-reference error or compiler crash.
+  Remove the alias and refer to a `val` holding the scrutinee as a workaround.
+
 - `Eq[DCert]` and `Eq[ScriptPurpose]` (Plutus V1) compared every field to itself: the inner
   pattern binder shadowed the outer one, so any two values with the same constructor were equal
   off-chain. On-chain the lowering replaces `Eq` with structural `equalsData`, which hid it

--- a/scalus-core/jvm/src/test/scala/scalus/compiler/PatternMatchWildcardRowOrderingTest.scala
+++ b/scalus-core/jvm/src/test/scala/scalus/compiler/PatternMatchWildcardRowOrderingTest.scala
@@ -5,7 +5,8 @@ import scalus.compiler.sir.TargetLoweringBackend
 import scalus.compiler.{compile, Options}
 import scalus.uplc.*
 import scalus.uplc.Term.asTerm
-import scalus.uplc.eval.PlutusVM
+import scalus.uplc.builtin.Builtins
+import scalus.uplc.eval.{PlutusVM, Result}
 import scalus.toUplc
 
 import scala.language.implicitConversions
@@ -24,6 +25,48 @@ class PatternMatchWildcardRowOrderingTest extends AnyFunSuite {
       optimizeUplc = true,
       debug = false
     )
+
+    test("failed wildcard guards run once when a constructor branch falls through") {
+        import scalus.cardano.onchain.plutus.prelude.Option
+        given Options = Options(
+          targetLoweringBackend = TargetLoweringBackend.SirToUplcV3Lowering,
+          optimizeUplc = false
+        )
+        val compiled = compile { (x: Option[BigInt], first: Boolean, last: Boolean) =>
+            x match
+                case Option.Some(v) if v > BigInt(10)    => BigInt(1)
+                case _ if Builtins.trace("first")(first) => BigInt(2)
+                case Option.Some(v) if v > BigInt(20)    => BigInt(3)
+                case _ if Builtins.trace("last")(last)   => BigInt(4)
+                case _                                   => BigInt(5)
+        }
+        val uplc = compiled.toUplc()
+        val some5 = compile { Option.Some(BigInt(5)) }.toUplc()
+        val some15 = compile { Option.Some(BigInt(15)) }.toUplc()
+        val none = compile { Option.None: Option[BigInt] }.toUplc()
+
+        def check(
+            arg: Term,
+            first: Boolean,
+            last: Boolean,
+            expected: Int,
+            traces: List[String]
+        ): Unit = {
+            (uplc $ arg $ first.asTerm $ last.asTerm).evaluateDebug match
+                case Result.Success(value, _, _, logs) =>
+                    assert(value == BigInt(expected).asTerm)
+                    // Debug logs append execution budgets to each trace message.
+                    assert(logs.map(_.takeWhile(_ != ':')).toList == traces)
+                case Result.Failure(error, _, _, _) => fail(error)
+        }
+
+        for arg <- List(some5, none) do {
+            check(arg, false, false, 5, List("first", "last"))
+            check(arg, false, true, 4, List("first", "last"))
+            check(arg, true, false, 2, List("first"))
+        }
+        check(some15, false, false, 1, Nil)
+    }
 
     test("guarded wildcard row between constructor cases keeps first-match priority") {
         import scalus.cardano.onchain.plutus.prelude.*

--- a/scalus-core/jvm/src/test/scala/scalus/compiler/plugin/AlternativeAliasErrorTest.scala
+++ b/scalus-core/jvm/src/test/scala/scalus/compiler/plugin/AlternativeAliasErrorTest.scala
@@ -1,0 +1,56 @@
+package scalus.compiler.plugin
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class AlternativeAliasErrorTest extends AnyFunSuite with SnippetCompilation {
+    private val diagnostic = "Aliases on alternative patterns are not supported in Scalus scripts."
+
+    for pattern <- List("x @ (\"a\" | \"b\")", "(x @ (\"a\" | \"b\")): String") do
+        test(s"alternative alias $pattern reports the unsupported-pattern error") {
+            val errors = compileSnippet(
+              s"""import scalus.compiler.*
+                 |object W {
+                 |  val sir = compile { (s: String) =>
+                 |    s match
+                 |      case $pattern => x
+                 |      case _ => "other"
+                 |  }
+                 |}
+                 |""".stripMargin
+            )
+            assert(errors.size == 1, s"expected one diagnostic, got: $errors")
+            assert(errors.head.startsWith(diagnostic), s"unexpected diagnostic: $errors")
+        }
+
+    test("nested alternative alias in a constructor guard is rejected without a compiler crash") {
+        val errors = compileSnippet(
+          """import scalus.compiler.*
+            |case class Box(value: String)
+            |object W {
+            |  val sir = compile { (box: Box) =>
+            |    box match
+            |      case Box(x @ ("a" | "b")) if x == "a" => x
+            |      case _ => "other"
+            |  }
+            |}
+            |""".stripMargin
+        )
+        assert(errors.size == 1, s"expected one diagnostic, got: $errors")
+        assert(errors.head.startsWith(diagnostic), s"unexpected diagnostic: $errors")
+    }
+
+    test("unaliased alternatives can return the original scrutinee") {
+        val errors = compileSnippet(
+          """import scalus.compiler.*
+            |object W {
+            |  val sir = compile { (s: String) =>
+            |    s match
+            |      case "a" | "b" => s
+            |      case _ => "other"
+            |  }
+            |}
+            |""".stripMargin
+        )
+        assert(errors.isEmpty, s"workaround must compile, got: $errors")
+    }
+}

--- a/scalus-plugin/src/main/scala/scalus/compiler/plugin/PatternMatchingCompiler.scala
+++ b/scalus-plugin/src/main/scala/scalus/compiler/plugin/PatternMatchingCompiler.scala
@@ -14,7 +14,8 @@ import scalus.compiler.plugin.SirParsedCase.{ActionRef, BindingNameInfo, Grouped
 import scalus.compiler.sir.*
 
 import scala.annotation.{tailrec, unused}
-import scala.collection.mutable.{ListBuffer, LongMap}
+import scala.collection.mutable
+import scala.collection.mutable.ListBuffer
 
 class PatternMatchingContext(
     val globalPrefix: String,
@@ -312,6 +313,10 @@ object SirParsedCase:
 
             override def optNameInfo: Option[BindingNameInfo] = None
 
+            // Alternative aliases are rejected in compileMatch. Unioning these bindings alone
+            // does not enable them: literal parsing discards aliases, typed aliases can still
+            // lose their binding, and guards such as x == "a" reject the inferred singleton
+            // union type ("a" | "b"). Support needs to address all three paths together.
             override def collectBindingInfos: Map[VariableKey, BindingNameInfo] = Map.empty
 
             override def show: String = patterns.map(_.show).mkString(" | ")
@@ -1340,6 +1345,8 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
       * full list of default rows — the default branch must see them too. Each group also records
       * how many default rows it already contains, so its fallback can skip them instead of
       * evaluating previously failed guards again. Trailing defaults are shared via the fallback.
+      * Before a DuplicateRows group reaches its fallback, each copied default has either been tried
+      * or structurally ruled out by a later column, so skipping it is sound in both cases.
       */
     private def collectSpecialized[P <: SirParsedCase.Pattern, K, V](
         rows: List[SirParsedCase.GroupedTupleRow],
@@ -1426,13 +1433,14 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
           SirCaseDecisionTree.SplitStrategy.DuplicateRows
         )
 
-        // Share continuations between constructor groups that consumed the same default rows.
-        // The default branch starts at zero; a specialized branch skips its copied prefix.
-        val continuations = LongMap.empty[Option[SirCaseDecisionTree.Reference]]
-        def continuation(skippedDefaults: Long): Option[SirCaseDecisionTree.Reference] =
+        // Share failure continuations between groups that consumed the same default prefix.
+        // The default branch and every group with no copied defaults share the zero entry,
+        // preserving the single fallback used by ordinary constructor matches.
+        val continuations = mutable.Map.empty[Int, Option[SirCaseDecisionTree.Reference]]
+        def failureContinuation(skipping: Int): Option[SirCaseDecisionTree.Reference] =
             continuations.getOrElseUpdate(
-              skippedDefaults, {
-                  val remaining = tail.drop(skippedDefaults.toInt)
+              skipping, {
+                  val remaining = tail.drop(skipping)
                   if remaining.isEmpty then optNextDecisionTree
                   else
                       val newGroup = SirParsedCase.GroupedTuples(
@@ -1452,7 +1460,11 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
               }
             )
 
-        val optNextSubtree = continuation(0)
+        // Allocate shared refs before building constructor subtrees, independently of map order.
+        val skippedPrefixes =
+            (0 :: constructorCases.valuesIterator.map(_._3).toList).distinct.sorted
+        skippedPrefixes.foreach(skipping => failureContinuation(skipping))
+        val optNextSubtree = failureContinuation(skipping = 0)
 
         val filledConstructorEntries = constructorCases.map {
             case (constrName, ((sirCaseClass, freeTypeParams), rows, copiedDefaults)) =>
@@ -1471,12 +1483,16 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
                 val constrPos = rows match
                     case head :: _ => head.pos
                     case Nil       => ctx.topLevelPos
+                // Count references where they enter the tree, not when the cache is read:
+                // buildGroupedTuplesDecisionTree counts an exhausted group, and nested choices
+                // count their default branches. This also covers nonzero shared continuations;
+                // counting here would double-count uses and count unreachable fallbacks.
                 val subtree =
                     buildGroupedTuplesDecisionTree(
                       ctx,
                       newGroup,
                       constrPos,
-                      continuation(copiedDefaults)
+                      failureContinuation(skipping = copiedDefaults)
                     )
                 val newGroupBindings = newGroup.columnBindings.drop(group.columnBindings.size)
                 val entry = SirCaseDecisionTree.ConstructorEntry(
@@ -1497,7 +1513,7 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
                         then {
                             //  btw, for some backends refTree may be compiled for each constructor,
                             //  for some - only once for all missing constructors.
-                            // We now count omce ans minimal heurisric.
+                            // Count once as a minimal heuristic.
                             ctx.countDecisionTreeRefUsage(refTree.index)
                         }
                     case None =>

--- a/scalus-plugin/src/main/scala/scalus/compiler/plugin/PatternMatchingCompiler.scala
+++ b/scalus-plugin/src/main/scala/scalus/compiler/plugin/PatternMatchingCompiler.scala
@@ -14,7 +14,7 @@ import scalus.compiler.plugin.SirParsedCase.{ActionRef, BindingNameInfo, Grouped
 import scalus.compiler.sir.*
 
 import scala.annotation.{tailrec, unused}
-import scala.collection.mutable.ListBuffer
+import scala.collection.mutable.{ListBuffer, LongMap}
 
 class PatternMatchingContext(
     val globalPrefix: String,
@@ -639,6 +639,25 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
         isUnchecked: Boolean = false
     ): AnnotatedSIR = {
         if env.debug then println(s"compileMatch: ${tree.show}")
+        // Reject aliases before compiling case bodies, where their missing bindings would
+        // otherwise produce an unrelated forward-reference error.
+        val aliasError = "Aliases on alternative patterns are not supported in Scalus scripts. " +
+            "Remove the alias and refer to a val holding the scrutinee instead."
+        var unsupportedAlias = false
+        def isAlternative(pattern: Tree): Boolean = pattern match
+            case Alternative(_)  => true
+            case Typed(inner, _) => isAlternative(inner)
+            case _               => false
+        val checkAliases = new tpd.TreeTraverser {
+            override def traverse(pattern: Tree)(using Context): Unit = pattern match
+                case Bind(_, inner) if isAlternative(inner) =>
+                    report.error(aliasError, pattern.srcPos)
+                    unsupportedAlias = true
+                case _ => traverseChildren(pattern)
+        }
+        tree.cases.foreach(c => checkAliases.traverse(c.pat))
+        if unsupportedAlias then return SIR.Error(aliasError, compiler.mkAnns(tree.srcPos, env))
+
         // The start column disambiguates multiple (possibly nested) matches on the same source
         // line - each match gets its own name counter, so a line-only prefix produced identical
         // generated names across them (audit M5).
@@ -1295,7 +1314,7 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
                 Some(SirCaseDecisionTree.Reference(nextIndex))
             }
 
-        val constEntries = withConstants.map { case (_, (const, rows)) =>
+        val constEntries = withConstants.map { case (_, (const, rows, _)) =>
             val newGroup = SirParsedCase.GroupedTuples(
               group.columnBindings,
               group.activeColumns - col,
@@ -1310,24 +1329,27 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
         SirCaseDecisionTree.ConstantChoice(columnName, tp, constEntries, optNextSubtree, pos)
     }
 
-    /** Collect rows with specialized pattern in the given column according to checkPattern function
-      * and splitStrategy. Return - Map[Key, (Value, List[Rows with this key])] and List of rest
-      * rows (i,e. default specialized) Key and Value are extracted from pattern by checkPattern
-      * function.
+    /** Collect rows with a specialized pattern in the given column. Return a map from each key to
+      * its value, rows, and number of copied default rows, together with the remaining/default
+      * rows. Keys and values are extracted by checkPattern.
       *
       * With DuplicateRows, a default row (non-matching pattern in this column) is duplicated into
       * every group at its source position, so first-match-wins is preserved: each group copies the
       * default rows it has not seen yet before appending its next specialized row, and a group
       * created later is seeded with all default rows collected so far. The returned rest is the
-      * full list of default rows — the default branch must see them too. Trailing default rows are
-      * not copied into groups: every group's subtree falls through to the rest.
+      * full list of default rows — the default branch must see them too. Each group also records
+      * how many default rows it already contains, so its fallback can skip them instead of
+      * evaluating previously failed guards again. Trailing defaults are shared via the fallback.
       */
     private def collectSpecialized[P <: SirParsedCase.Pattern, K, V](
         rows: List[SirParsedCase.GroupedTupleRow],
         colIndex: Int,
         checkPattern: SirParsedCase.Pattern => Option[(P, K, V)],
         splitStrategy: SirCaseDecisionTree.SplitStrategy
-    ): (Map[K, (V, List[SirParsedCase.GroupedTupleRow])], List[SirParsedCase.GroupedTupleRow]) = {
+    ): (
+        Map[K, (V, List[SirParsedCase.GroupedTupleRow], Int)],
+        List[SirParsedCase.GroupedTupleRow]
+    ) = {
         var groupedRows: Map[K, (V, ListBuffer[SirParsedCase.GroupedTupleRow])] = Map.empty
         val defaultRows: ListBuffer[SirParsedCase.GroupedTupleRow] = ListBuffer.empty
         var copiedDefaults: Map[K, Int] = Map.empty
@@ -1360,7 +1382,7 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
             if !done then cursor = cursor.tail
         }
         val grouped = groupedRows.map { case (k, (v, buf)) =>
-            (k, (v, buf.toList))
+            (k, (v, buf.toList, copiedDefaults(k)))
         }
         splitStrategy match {
             case SirCaseDecisionTree.SplitStrategy.DuplicateRows =>
@@ -1404,26 +1426,36 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
           SirCaseDecisionTree.SplitStrategy.DuplicateRows
         )
 
-        val optNextSubtree =
-            if tail.isEmpty then optNextDecisionTree
-            else
-                val newGroup = SirParsedCase.GroupedTuples(
-                  group.columnBindings,
-                  group.activeColumns - colIndex,
-                  tail
-                )
-                val nextSubtree = buildGroupedTuplesDecisionTree(
-                  ctx,
-                  newGroup,
-                  tail.head.pos,
-                  optNextDecisionTree
-                )
-                val nextIndex = ctx.decisionTreeRefs.length
-                ctx.decisionTreeRefs = ctx.decisionTreeRefs.appended(nextSubtree)
-                Some(SirCaseDecisionTree.Reference(nextIndex))
+        // Share continuations between constructor groups that consumed the same default rows.
+        // The default branch starts at zero; a specialized branch skips its copied prefix.
+        val continuations = LongMap.empty[Option[SirCaseDecisionTree.Reference]]
+        def continuation(skippedDefaults: Long): Option[SirCaseDecisionTree.Reference] =
+            continuations.getOrElseUpdate(
+              skippedDefaults, {
+                  val remaining = tail.drop(skippedDefaults.toInt)
+                  if remaining.isEmpty then optNextDecisionTree
+                  else
+                      val newGroup = SirParsedCase.GroupedTuples(
+                        group.columnBindings,
+                        group.activeColumns - colIndex,
+                        remaining
+                      )
+                      val nextSubtree = buildGroupedTuplesDecisionTree(
+                        ctx,
+                        newGroup,
+                        remaining.head.pos,
+                        optNextDecisionTree
+                      )
+                      val nextIndex = ctx.decisionTreeRefs.length
+                      ctx.decisionTreeRefs = ctx.decisionTreeRefs.appended(nextSubtree)
+                      Some(SirCaseDecisionTree.Reference(nextIndex))
+              }
+            )
+
+        val optNextSubtree = continuation(0)
 
         val filledConstructorEntries = constructorCases.map {
-            case (constrName, ((sirCaseClass, freeTypeParams), rows)) =>
+            case (constrName, ((sirCaseClass, freeTypeParams), rows, copiedDefaults)) =>
                 if ctx.env.debug then
                     println(
                       s"buildSpecializedConstr: constrName=${constrName}, sirCaseClass=${sirCaseClass.show} nRows=${rows.length}"
@@ -1440,7 +1472,12 @@ class PatternMatchingCompiler(val compiler: SIRCompiler)(using Context) {
                     case head :: _ => head.pos
                     case Nil       => ctx.topLevelPos
                 val subtree =
-                    buildGroupedTuplesDecisionTree(ctx, newGroup, constrPos, optNextSubtree)
+                    buildGroupedTuplesDecisionTree(
+                      ctx,
+                      newGroup,
+                      constrPos,
+                      continuation(copiedDefaults)
+                    )
                 val newGroupBindings = newGroup.columnBindings.drop(group.columnBindings.size)
                 val entry = SirCaseDecisionTree.ConstructorEntry(
                   sirCaseClass,


### PR DESCRIPTION
Constructor-pattern fallbacks can restart wildcard guards that have already failed, changing traces and increasing execution cost. Resume each fallback after the default rows already tried or structurally ruled out by its constructor group. Share failure continuations through an Int-keyed map and allocate them in sorted prefix order. The regression test checks that `first, first, last` becomes `first, last`, while preserving early exits and default-branch behavior.

Reject unsupported aliases such as `x @ ("a" | "b")` at the pattern, before compiling guards or case bodies. This produces one actionable diagnostic instead of a misleading forward-reference error. Packaged-plugin compilation tests cover plain, typed, and nested aliases, plus the supported workaround of referring to the original scrutinee.

Alias support remains deferred: combining alternative bindings alone fails all six experimental cases. Preserving literal bindings too enables direct and nested aliases in case bodies, but typed aliases still lose their binding and guards reject singleton-union string equality. The compiler comments document these blockers.

Reference-use counts are recorded where fallbacks enter the decision tree, including nonzero shared continuations; cache lookups must not count them again. An Unreleased changelog entry covers the diagnostic and script-budget changes.

Validation: `sbtn quick` in the isolated PR worktree.
